### PR TITLE
Added time to the recurring date parser

### DIFF
--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -1,7 +1,7 @@
 class Usergroup
   attr_accessor :label_id, :domains, :recurring, :email, :mailing_list, :host, :twitter, :usergroup_email, :organizers, :location, :imprint, :other_usergroups
 
-  def parse_recurring(date)
+  def parse_recurring_date(date)
     num, day = recurring.split
     day = Date::DAYS_INTO_WEEK[day.to_sym] + 1
     num = %w(first second third).index(num)
@@ -13,9 +13,20 @@ class Usergroup
     end
   end
 
+  def parse_recurring_time
+    num, day, time_string = recurring.split
+    if time_string.present?
+      hour, min = time_string.split(':')
+      t = Time.new(2012, 5, 1, hour.to_i, min.to_i)
+    else
+      t = Time.new(2012, 5, 1, 19, 0)
+    end
+  end
+
   def next_event_date
-    d = parse_recurring(Date.today)
-    d = parse_recurring(Date.today.next_month) unless d.future?
-    Time.new(d.year, d.month, d.day, 19, 0)
+    d = parse_recurring_date(Date.today)
+    d = parse_recurring_date(Date.today.next_month) unless d.future?
+    t = parse_recurring_time
+    Time.new(d.year, d.month, d.day, t.hour, t.min)
   end
 end

--- a/spec/models/usergroup_spec.rb
+++ b/spec/models/usergroup_spec.rb
@@ -18,10 +18,33 @@ describe Usergroup do
       end
     end
 
+    it 'should include the parsed time, also' do
+      rughh.recurring = 'second wednesday 18:30'
+      rughh.next_event_date.hour.should eq(18)
+      rughh.next_event_date.min.should eq(30)
+    end
+  end
+
+  describe '#parse_recurring_date' do
     it "should find the right wednesday" do
-      hackhb.parse_recurring(some_date).should eql(first_wednesday)
-      rughh.parse_recurring(some_date).should eql(second_wednesday)
-      colognerb.parse_recurring(some_date).should eql(third_wednesday)
+      hackhb.parse_recurring_date(some_date).should eql(first_wednesday)
+      rughh.parse_recurring_date(some_date).should eql(second_wednesday)
+      colognerb.parse_recurring_date(some_date).should eql(third_wednesday)
+    end
+  end
+
+  describe '#parse_recurring_time' do
+    it "should return a time with 19:00 as default" do
+      parsed_time = hackhb.parse_recurring_time
+      parsed_time.hour.should eql(19)
+      parsed_time.min.should eql(0)
+    end
+
+    it "should parse the recurring time" do
+      rughh.recurring = 'second wednesday 18:30'
+      parsed_time = rughh.parse_recurring_time
+      parsed_time.hour.should eql(18)
+      parsed_time.min.should eql(30)
     end
   end
 end


### PR DESCRIPTION
Usually, our events at RUGSaar are on 19:30 instead of 19:00.

The recurring parser now supports the format like

``` ruby
"third wednesday 19:30"
```

for specifying the time as well.

The default is left to 19:00, of course. :smirk:
