### PR TITLE
Styling of Homepage

### DIFF
--- a/app/assets/stylesheets/screen.css.sass
+++ b/app/assets/stylesheets/screen.css.sass
@@ -237,6 +237,12 @@ nav
     background: url(/assets/black-Linen.png) left top repeat
     img
       vertical-align: middle
+    span.image
+      display: inline-block
+      width: 140px
+      text-align: center
+      img
+        max-width: 120px
 
   section
     padding: 2em
@@ -467,3 +473,11 @@ footer
     left: 0px
   &#github_ribbon
     right: 0px
+
+//just front page
+#labels
+  .hint .close
+    display: none
+  header
+    padding: 5px
+

--- a/app/views/home/labels.slim
+++ b/app/views/home/labels.slim
@@ -5,4 +5,6 @@
         - name = t("label.#{label.label_id}.name")
         = link_to root_url(subdomain: label.label_id), title: name do
           .whitelabel
-            #{image_tag("labels/#{label.label_id}.png", alt: name)} #{label.host}
+            span.image = image_tag("labels/#{label.label_id}.png", alt: name)
+
+            span.host  = label.host

--- a/app/views/layouts/labels.html.slim
+++ b/app/views/layouts/labels.html.slim
@@ -11,7 +11,7 @@ html
     = touch_icon
     = stylesheet_link_tag "application"
 
-  body
+  body#labels
     .container
       header
       .main


### PR DESCRIPTION
I made some minor UI changes to the labels home page:
- aligned the images and titles by defining a maxwidth for the image container
- hide the close button on the "Choose your community" alert text - which makes no sense at this point
- reduce (empty) header height, so content comes earlier

![preview](https://f.cloud.github.com/assets/147175/62126/d88e18aa-5cdb-11e2-851e-add1147eb60b.jpg)

I also want to improve the admin UI, e.g.: selecting the right user as organizer of an event, is a little bit tedious, maybe also using a better date/time-picker, if that is ok.
