### PR TITLE
Fix error where twitter link on user profile showed just URL

### DIFF
--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -2,6 +2,7 @@
 module ExternalLinkHelper
   def link_to_twitter(thing, params={clung: false}, &block)
     nick = thing.respond_to?(:twitter) ? thing.twitter : thing
+    return "none given" if nick.empty?
     url = "http://twitter.com/#{nick}"
     if block_given?
       link_to url, title: nick, &block


### PR DESCRIPTION
If one signed in with one's GitHub account, the twitter handle would
not be set and therefore produce erroneous output.

![Screen Shot 2013-03-05 at 3 30 53 PM](https://f.cloud.github.com/assets/237985/221572/81c092d4-85a1-11e2-86d1-a93322173f3d.png)
