### PR TITLE
adds pubDate field to events.xml feed

### DIFF
--- a/app/views/events/index.xml.builder
+++ b/app/views/events/index.xml.builder
@@ -12,6 +12,7 @@ xml.rss "version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/" do
        xml.link        url_for only_path: false, controller: 'events', action: 'show', id: event.id
        xml.description event.description
        xml.guid        url_for only_path: false, controller: 'events', action: 'show', id: event.id
+       xml.pubDate     event.created_at.rfc822
      end
    end
  end


### PR DESCRIPTION
Some news readers are easily confused with non dated items and display
them at wrong dates. (Looking at you, feedy!)
All events will no be set to be published on their created_at
time.
