### PR TITLE
add pod with discussions from mailing list to the home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "acts_as_api",            "0.4.1"
 gem "whitelabel",             "0.2.0"
 gem "dalli",                  "2.6.4"
 gem 'exception_notification', github: 'smartinez87/exception_notification'
+gem "feedzirra",              "0.2.0.rc2"
 
 gem "formtastic",             "2.2.1"
 gem "kaminari",               "0.14.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       rest-client
       simplecov (>= 0.7)
       thor
+    curb (0.8.4)
     daemons (1.1.9)
     dalli (2.6.4)
     debug_inspector (0.0.2)
@@ -111,6 +112,12 @@ GEM
       i18n (~> 0.5)
     faraday (0.8.7)
       multipart-post (~> 1.1)
+    feedzirra (0.2.0.rc2)
+      curb (~> 0.8.0)
+      gorillib (~> 0.1.9)
+      loofah (~> 1.2.1)
+      nokogiri (~> 1.5.3)
+      sax-machine (~> 0.2.0.rc1)
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
@@ -118,6 +125,8 @@ GEM
       actionpack (>= 3.0)
     fssm (0.2.10)
     geocoder (1.1.8)
+    gorillib (0.1.11)
+      json
     hashie (2.0.5)
     hike (1.2.3)
     httpauth (0.2.0)
@@ -128,6 +137,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery_mobile_rails (1.3.0)
       railties (>= 3.1.0)
+    json (1.8.0)
     jwt (0.1.8)
       multi_json (>= 1.5)
     kaminari (0.14.1)
@@ -137,6 +147,8 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.1.1)
       launchy (~> 2.2)
+    loofah (1.2.1)
+      nokogiri (>= 1.4.4)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -152,6 +164,7 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.7.7)
     multipart-post (1.2.0)
+    nokogiri (1.5.10)
     oauth (0.4.7)
     oauth2 (0.8.1)
       faraday (~> 0.8)
@@ -229,6 +242,8 @@ GEM
       railties (>= 4.0.0.beta, < 5.0)
       sass (>= 3.1.10)
       sprockets-rails (~> 2.0.0)
+    sax-machine (0.2.0.rc1)
+      nokogiri (~> 1.5.2)
     sequel (3.20.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
@@ -293,6 +308,7 @@ DEPENDENCIES
   exception_notification!
   factory_girl_rails (= 4.2.1)
   faker (= 1.1.2)
+  feedzirra (= 0.2.0.rc2)
   foreman
   formtastic (= 2.2.1)
   friendly_id!

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  helper MailingListHelper
+
   expose(:current_event) { Event.current.first }
   expose(:events) { Event.latest.limit(10) }
   expose(:people) { User.peers }

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -11,7 +11,9 @@ module HomeHelper
     content_for :mobile_navigation do
       content_tag :div, data: {role: "navbar", iconpos: "right"} do
         content_tag :ul do
-          [:events, :topics, :people, :locations].each do |it|
+          nav_entries = [:events, :topics, :people, :locations]
+          nav_entries.insert(2, :mailing_list) if Whitelabel[:mailing_list_feed_url].present?
+          nav_entries.each do |it|
             concat(content_tag :li, link_to(t(it), root_path(anchor: it), class: it == :events ? "ui-btn-active" : ""))
           end
         end

--- a/app/helpers/mailing_list_helper.rb
+++ b/app/helpers/mailing_list_helper.rb
@@ -1,0 +1,12 @@
+require 'feedzirra'
+
+module MailingListHelper
+  def mailing_list_entries(count = 15)
+    feed_url = Whitelabel[:mailing_list_feed_url]
+    if feed = Feedzirra::Feed.fetch_and_parse(feed_url)
+      feed.entries[0..count-1]
+    else
+      []
+    end
+  end
+end

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -3,7 +3,7 @@ class Usergroup
   DELIMITER_DATE = ' '
   NUMBERS        = %w(first second third)
 
-  attr_accessor :label_id, :default_locale, :domains, :recurring, :email, :mailing_list
+  attr_accessor :label_id, :default_locale, :domains, :recurring, :email, :mailing_list, :mailing_list_feed_url
   attr_accessor :host, :twitter, :usergroup_email, :organizers, :location, :imprint, :other_usergroups
   attr_accessor :theme
 

--- a/app/views/home/_mailing_list.slim
+++ b/app/views/home/_mailing_list.slim
@@ -1,0 +1,9 @@
+= section_box :mailing_list do
+  p
+    == t("home.mailing_list")
+  = button_to t("home.goto_maling_list"), Whitelabel[:mailing_list], method: :get
+  #done
+    h3= t('home.top_maling_entries')
+    ul.more-list.clearfix
+      - mailing_list_entries.each do |entry|
+        li.mailing_entry= link_to(entry.title, entry.url)

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -1,5 +1,6 @@
 - render_cached do
   = render 'events', events: events, current_event: current_event
   = render 'topics', undone_topics: undone_topics, done_topics: done_topics, organizers: organizers
+  = render 'mailing_list' if Whitelabel[:mailing_list_feed_url].present?
   = render 'people', people: people
   = render 'locations', locations: locations

--- a/app/views/mobile/home/_mailing_list.slim
+++ b/app/views/mobile/home/_mailing_list.slim
@@ -1,0 +1,5 @@
+ul#mailing_list data-role="listview"
+  li(data-role="list-divider")
+  - mailing_list_entries(5).each do |entry|
+    li= link_to(entry.title, entry.url)
+  li.ui-body= button_to t("home.goto_maling_list"), Whitelabel[:mailing_list], method: :get, data: {icon: 'arrow-r'}

--- a/app/views/mobile/home/index.slim
+++ b/app/views/mobile/home/index.slim
@@ -1,5 +1,6 @@
 - mobile_navigation
 = render 'events', current_event: current_event, events: events
 = render 'topics', undone_topics: undone_topics, done_topics: done_topics
+= render 'mailing_list' if Whitelabel[:mailing_list_feed_url].present?
 = render 'people', people: people[0..9]
 = render 'locations', locations: locations

--- a/app/views/shared/_nav.html.slim
+++ b/app/views/shared/_nav.html.slim
@@ -1,5 +1,7 @@
 ul
-  - [:events, :topics, :people, :locations].each do |it|
+  - nav_entries = [:events, :topics, :people, :locations]
+  - nav_entries.insert(2, :mailing_list) if Whitelabel[:mailing_list_feed_url].present?
+  - nav_entries.each do |it|
     li= link_to t(it), root_path(anchor: it), title: t(it)
 
 #locale

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -12,6 +12,7 @@ de:
     en: "Englisch"
   usergroups: "Usergroups"
   events: "Treffen"
+  mailing_list: "Mailinglist"
   locations: "Orte"
   people: "Leute"
   topics: "Themen"
@@ -63,6 +64,9 @@ de:
     no_new_topics: "Es gibt im Moment keine Themenvorschläge, trage hier deinen %{new_topic_link} ein!"
     all_events: "Alle Events"
     all_people: "Alle Leute"
+    top_maling_entries: "Top Diskussionen"
+    goto_maling_list: "Zur Mailinglist"
+    mailing_list: "Die Mailinglist ist eine Möglichkeit stets auf dem Laufenden zu bleiben oder sich an Diskussionsthemen zu beteiligen. Sie wird dafür verwendet jeden über Neuigkeiten per E-Mail zu informieren, der sich dafür eingeschrieben hat. Organisatorische, fachliche und andere interessante Dinge werden hier diskutiert und abgestimmt. Keine Werbung - keine Scheu."
   profile:
     edit: "Profil bearbeiten"
     freelancer: "Freiberufler"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
     en: "English"
   usergroups: "Usergroups"
   events: "Events"
+  mailing_list: "Mailinglist"
   locations: "Locations"
   people: "People"
   topics: "Topics"
@@ -63,6 +64,9 @@ en:
     no_new_topics: "Currently no proposals, add your %{new_topic_link} here!"
     all_events: "All Events"
     all_people: "All People"
+    top_maling_entries: "Top discussions"
+    goto_maling_list: "To the Mailinglist"
+    mailing_list: "The Mailinglist is a tool to just stay up-to-date or to even get involved in discussions. It is used to inform everyone about News via e-mail who signed up for it. Organizational, technical and other interesting topics are discussed and coordinated here. No ads - no dread."
   profile:
     edit: "Edit profile"
     freelancer: "Freelancer"

--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -177,6 +177,7 @@
   recurring: "third thursday 19:00"
   email: "leipzigonrails@googlegroups.com"
   mailing_list: "https://groups.google.com/group/leipzigonrails"
+  mailing_list_feed_url: "https://groups.google.com/forum/feed/leipzigonrails/topics/rss.xml?num=15"
   host: "leipzig.onruby.de"
   twitter: "LeipzigOnRails"
   organizers: ['cpetschnig', 'knugie', 'tmetzmac']

--- a/spec/helpers/mailing_list_helper_spec.rb
+++ b/spec/helpers/mailing_list_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe MailingListHelper do
+  context "the feed is available" do
+    let(:entry) { stub(:title => 'A nice title', :url => 'http://some.url/a_nice_title') }
+    let(:feed) { stub(:entries => [entry]) }
+
+    it "should return the entries for the feed" do
+      Feedzirra::Feed.stubs(:fetch_and_parse).returns(feed)
+
+      helper.mailing_list_entries.should == feed.entries
+    end
+  end
+
+  context "the feed was not available or not set" do
+    it "should return a empty array" do
+      helper.mailing_list_entries.should == []
+    end
+  end
+end


### PR DESCRIPTION
Hi folk,
the mailing list is the most important communication way for our user group. So we need making the mailing list more visible on the onruby page. I made a proposal to implement this.

![bildschirmfoto 2013-08-04 um 11 06 30](https://f.cloud.github.com/assets/419651/906827/3289b2de-fce5-11e2-9dd9-308e06ef9dc5.png)

You must set the "mailing_list_feed_url" setting in the whitelabel.yml for you usergroup to activate the mailing list pod.
