### PR TITLE
option to override some text

### DIFF
--- a/app/concerns/whitelabel_translation.rb
+++ b/app/concerns/whitelabel_translation.rb
@@ -1,7 +1,7 @@
 module WhitelabelTranslation
   def translate_whitelabel(token, options = {})
     sub = Whitelabel.label ? Whitelabel[:label_id] : "default"
-    t(token, options.merge(scope: "label.#{sub}"))
+    t("label.#{sub}.#{token}".to_sym, options.merge(default: ["label.default.#{token}".to_sym,token.to_sym]))
   end
   alias :tw :translate_whitelabel
 end

--- a/app/views/events/show.slim
+++ b/app/views/events/show.slim
@@ -14,7 +14,7 @@ section
   == markdown event.description
 
   - if event.participants.present?
-    h3= "#{t("show.attendees")} (#{event.participants.count})"
+    h3= "#{I18n.tw("show.attendees")} (#{event.participants.count})"
     p= render 'users/list', users: event.users
 
   = render "topics", topics: event.topics

--- a/app/views/home/_events.slim
+++ b/app/views/home/_events.slim
@@ -8,8 +8,8 @@
           - current_event.topics.each do |topic|
             li.topic= link_to_topic topic
   - else
-    p== t("home.next_possible_meetup_recurring", recurring: content_tag(:em, localized_recurring_event_date))
-    p== t("home.next_possible_meetup", event_date: content_tag(:em, next_event_date))
+    p== I18n.tw("home.next_possible_meetup_recurring", recurring: content_tag(:em, localized_recurring_event_date))
+    p== I18n.tw("home.next_possible_meetup", event_date: content_tag(:em, next_event_date))
   - if events.any?
     h3= t("home.past_events")
     ul.more-list.clearfix

--- a/app/views/home/_locations.slim
+++ b/app/views/home/_locations.slim
@@ -1,7 +1,7 @@
 = section_box :locations do
   = map(locations)
   - options = { location_link: link_to(t("locations"), locations_path, title: t("locations")) }
-  p== t("home.usergroup_locations", options)
-  p== t("home.company_workers")
+  p== I18n.tw("home.usergroup_locations", options)
+  p== I18n.tw("home.company_workers")
   - options = { email_link: mail_to(Whitelabel[:email], "E-Mail", title: "E-Mail"), twitter_link: link_to_twitter(Whitelabel[:twitter]) }
-  p== t("home.company_missing", options)
+  p== I18n.tw("home.company_missing", options)

--- a/app/views/home/_mailing_list.slim
+++ b/app/views/home/_mailing_list.slim
@@ -1,5 +1,5 @@
 = section_box :mailing_list do
-  p= t("home.mailing_list")
+  p= I18n.tw("home.mailing_list")
   #done
     h3= t('home.top_maling_entries')
     ul.more-list.clearfix

--- a/app/views/home/_people.slim
+++ b/app/views/home/_people.slim
@@ -1,3 +1,3 @@
 = section_box :people do
-  p== t("home.the_usergroup", usergroup: I18n.tw("name"))
+  p== I18n.tw("home.the_usergroup", usergroup: I18n.tw("name"))
   = render 'users/list', users: people

--- a/app/views/home/_topics.slim
+++ b/app/views/home/_topics.slim
@@ -1,9 +1,9 @@
 = section_box :topics do
   p
-    strong=' t("home.like_to_talk")
+    strong=' I18n.tw("home.like_to_talk")
     == t("home.send_us_an_email", mail_to: mail_to(Whitelabel[:email], "E-Mail", title: "E-Mail"))
   = render 'users/list', users: organizers
-  p== t("home.engage")
+  p== I18n.tw("home.engage")
   = button_to t("home.add_topic"), new_topic_path, method: :get
   = render 'topics/undone', topics: undone_topics
   = render 'topics/done', topics: done_topics

--- a/app/views/mobile/events/show.slim
+++ b/app/views/mobile/events/show.slim
@@ -12,7 +12,7 @@ div data-role="collapsible-set"
       li= map(event.location, lat: event.location.lat, long: event.location.long)
       li(data-icon="forward")= link_to event.location.address, "http://maps.apple.com/?q=#{event.location.address}"
   div data-role="collapsible" class="#{event.participants.present? ? '' : 'ui-disabled'}"
-    h2= t("show.attendees")
+    h2= I18n.tw("show.attendees")
     ul data-role="listview"
       - event.users.each do |user|
         li= link_to user do

--- a/app/views/mobile/home/_events.slim
+++ b/app/views/mobile/home/_events.slim
@@ -9,7 +9,7 @@ ul#events data-role="listview"
           strong= event.location.name
         p
           strong=' event.participants.count
-          = t('show.attendees')
+          = I18n.tw('show.attendees')
         p
           strong=' event.topics.count
           = t('topics')
@@ -23,7 +23,7 @@ ul#events data-role="listview"
           strong= event.location.name
         p
           strong=' event.participants.count
-          = t('show.attendees')
+          = I18n.tw('show.attendees')
         p
           strong=' event.topics.count
           = t('topics')

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -24,7 +24,7 @@ section.clearfix
 
   - if other_usergroups.present?
     .usergroups.block.hr
-      h2= t("footer.other_usergroups")
+      h2= I18n.tw("footer.other_usergroups")
       ol.clearfix
         - other_usergroups.each do |ug|
           li

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -3,7 +3,7 @@ section
     .imagelist= image_tag user.image, size: '48x48', alt: user.name
     h3
       = user.name
-      = user.freelancer? ? " / #{t("profile.freelancer")}" : ''
+      = user.freelancer? ? " / #{I18n.tw("profile.freelancer")}" : ''
       = user.available? ? " / #{t("profile.available")}" : ''
 
     div.badges.small


### PR DESCRIPTION
As an organizer of a non-standard group, I need the possibility to override some of the text resources.

So far, the code in this pull request only allows overriding of _some_ resources. In the future, we may consider to use I18n.tw througout the app to make _every_ resource customizable (or monkey-patch the t helper instead, if someone's feeling brave ;-)
