### PR TITLE
hide headline if there are no mailinglist top threads (e.g. list not public)

### DIFF
--- a/app/views/home/_mailing_list.slim
+++ b/app/views/home/_mailing_list.slim
@@ -1,7 +1,8 @@
 = section_box :mailing_list do
   p= t("home.mailing_list")
   #done
-    h3= t('home.top_maling_entries')
+    - unless mailing_list_entries.empty?
+        h3= t('home.top_maling_entries')
     ul.more-list.clearfix
       - mailing_list_entries.each do |entry|
         li.mailing_entry= link_to(entry.title, entry.url, title: entry.title)


### PR DESCRIPTION
If the mailinglist is not public, there are no threads to be displayed. So the headline should not be displayed as well.
