### PR TITLE
Use SVG for status badges in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # OnRuby
-[![Build Status](https://secure.travis-ci.org/phoet/on_ruby.png)](https://travis-ci.org/phoet/on_ruby)
-[![Code Climate](https://codeclimate.com/github/phoet/on_ruby.png)](https://codeclimate.com/github/phoet/on_ruby)
-[![Coverage Status](https://coveralls.io/repos/phoet/on_ruby/badge.png?branch=master)](https://coveralls.io/r/phoet/on_ruby?branch=master)
+[![Build Status](https://img.shields.io/travis/phoet/on_ruby/master.svg)](https://travis-ci.org/phoet/on_ruby)
+[![Code Climate](https://img.shields.io/codeclimate/github/phoet/on_ruby.svg)](https://codeclimate.com/github/phoet/on_ruby)
+[![Coverage Status](https://img.shields.io/coveralls/phoet/on_ruby/master.svg)](https://coveralls.io/r/phoet/on_ruby?branch=master)
 
 
 Source for the Sites of the Ruby Communities [Hamburg](http://hamburg.onruby.de), [Bremen](http://bremen.onruby.de), [Cologne](http://cologne.onruby.de), [Saarland](http://saar.onruby.de), [Berlin](http://berlin.onruby.de), [Leipzig](http://leipzig.onruby.de), [Karlsruhe](http://karlsruhe.onruby.de), [Dresden](http://dresden.onruby.de), [Railsgirls Hamburg](http://railsgirlshh.onruby.de)


### PR DESCRIPTION
http://shields.io/ provides many standardized badges for OSS. The PNG versions provided by Shields are similar to the images currently used, but the SVG versions added here are more legible on high pixel density displays.
