### PR TITLE
Materials Preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "peek-gc",                "~> 0.0.2"
 gem "peek-git",               "~> 1.0.2"
 gem "peek-performance_bar",   "~> 1.1.3"
 gem "zero_push",              "~> 2.4.1"
+gem 'link_thumbnailer',       "~> 2.4.0"
 
 group :production, :caching do
   gem "heroku-deflater",  "~> 0.5.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
+    fastimage (1.6.6)
+      addressable (~> 2.3, >= 2.3.5)
     feedjira (1.6.0)
       curb (~> 0.8)
       loofah (~> 2.0)
@@ -135,6 +137,7 @@ GEM
     heroku-deflater (0.5.3)
       rack (>= 1.4.5)
     hike (1.2.3)
+    htmlentities (4.3.3)
     i18n (0.7.0)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
@@ -149,6 +152,14 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.3.0)
       launchy (~> 2.2)
+    link_thumbnailer (2.4.0)
+      activesupport (>= 3.0)
+      fastimage (~> 1.6)
+      json (~> 1.7, >= 1.7.7)
+      net-http-persistent (~> 2.9)
+      nokogiri (~> 1.6)
+      rake (>= 0.9)
+      video_info (~> 2.3)
     lograge (0.3.0)
       actionpack (>= 3)
       activesupport (>= 3)
@@ -168,6 +179,7 @@ GEM
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
     newrelic_rpm (3.9.9.275)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
@@ -341,6 +353,10 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    video_info (2.4.0)
+      addressable
+      htmlentities
+      multi_json
     whitelabel (0.2.0)
     zero_push (2.4.1)
       faraday (~> 0.9.0)
@@ -372,6 +388,7 @@ DEPENDENCIES
   kaminari (~> 0.15.0)
   kgio (~> 2.9.2)
   letter_opener
+  link_thumbnailer (~> 2.4.0)
   lograge (~> 0.3.0)
   meta_request
   newrelic_rpm (~> 3.9)

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -441,3 +441,28 @@ footer
         text-align: center
         img
           max-width: 120px
+
+.preview
+  margin-top: 1em
+  margin-bottom: 1em
+
+  &.video
+    height: 29em
+    iframe
+      height: 100%
+      width: 100%
+
+  &.image
+    height: 10em
+    overflow: hidden
+    a
+      height: 100%
+      width: 100%
+      display: block
+      img
+        max-height: 100%
+        max-width: 100%
+        display: block
+        margin: auto
+
+

--- a/app/concerns/preview_generator.rb
+++ b/app/concerns/preview_generator.rb
@@ -11,9 +11,9 @@ class PreviewGenerator
   def generate_preview()
     website = LinkThumbnailer.generate(uri)
 
-    video = website.videos.find { |v| v.embedded_code.present? }
+    video = website.videos.find { |v| v.embed_code.present? }
     if video then
-      self.code = video.embedded_code
+      self.code = video.embed_code
       self.type = :video
     else
       image = website.images.first

--- a/app/concerns/preview_generator.rb
+++ b/app/concerns/preview_generator.rb
@@ -1,0 +1,42 @@
+class PreviewGenerator
+
+  attr_accessor :uri
+  attr_accessor :type
+  attr_accessor :code
+
+  def initialize(uri)
+    @uri = uri
+  end
+
+  def generate_preview()
+    website = LinkThumbnailer.generate(uri)
+
+    video = website.videos.find { |v| v.embedded_code.present? }
+    if video then
+      self.code = video.embedded_code
+      self.type = :video
+    else
+      image = website.images.first
+      if image then
+        self.code = image.src
+        self.type = :image
+      else
+        self.type = :none
+      end
+    end
+
+  end
+
+  def video?
+    self.type == :video
+  end
+
+  def image?
+    self.type == :image
+  end
+
+  def none?
+    self.type == :none
+  end
+
+end

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -1,0 +1,19 @@
+module PreviewHelper
+
+  def material_preview(material)
+    return "" if material.preview_type.nil? or material.preview_type == 'none'
+
+    if material.preview_type == 'video'
+      content_tag :div, class: 'preview video' do
+        material.preview_code.html_safe
+      end
+    elsif material.preview_type == 'image'
+      content_tag :div, class: 'preview image' do
+        link_to material.url, title: material.name do
+          image_tag(material.preview_code, alt: material.name)
+        end
+      end
+    end
+  end
+
+end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -8,4 +8,13 @@ class Material < ActiveRecord::Base
   belongs_to :event
 
   default_scope -> { joins(:event).where("events.label" => Whitelabel[:label_id]).readonly(false) }
+
+  def generate_preview
+    generator = PreviewGenerator.new(self.url)
+    generator.generate_preview
+    self.preview_type = generator.type
+    self.preview_code = generator.code
+    save
+  end
+
 end

--- a/app/views/events/_materials.slim
+++ b/app/views/events/_materials.slim
@@ -5,3 +5,4 @@
       li
         = link_to_material(material)
         == " (#{link_to_user(material.user)})" if material.user
+        = material_preview(material)

--- a/config/initializers/link_thumbnailer.rb
+++ b/config/initializers/link_thumbnailer.rb
@@ -1,0 +1,71 @@
+# Use this hook to configure LinkThumbnailer bahaviors.
+LinkThumbnailer.configure do |config|
+  # Numbers of redirects before raising an exception when trying to parse given url.
+  #
+  config.redirect_limit = 3
+
+  # Set user agent
+  #
+  # config.user_agent = 'link_thumbnailer'
+
+  # Enable or disable SSL verification
+  #
+  # config.verify_ssl = true
+
+  # The amount of time in seconds to wait for a connection to be opened.
+  # If the HTTP object cannot open a connection in this many seconds,
+  # it raises a Net::OpenTimeout exception.
+  #
+  # See http://www.ruby-doc.org/stdlib-2.1.1/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout
+  #
+  config.http_timeout = 10
+
+  # List of blacklisted urls you want to skip when searching for images.
+  #
+  config.blacklist_urls = [
+    %r{^http://ad\.doubleclick\.net/},
+    %r{^http://b\.scorecardresearch\.com/},
+    %r{^http://pixel\.quantserve\.com/},
+    %r{^http://s7\.addthis\.com/}
+  ]
+
+  # List of attributes you want LinkThumbnailer to fetch on a website.
+  #
+  config.attributes = [:title, :images, :videos]
+
+  # List of procedures used to rate the website description. Add you custom class
+  # here. Note that the order matter to compute the score. See wiki for more details
+  # on how to build your own graders.
+  #
+  # config.graders = [
+  #   ->(description) { ::LinkThumbnailer::Graders::Length.new(description) },
+  #   ->(description) { ::LinkThumbnailer::Graders::HtmlAttribute.new(description, :class) },
+  #   ->(description) { ::LinkThumbnailer::Graders::HtmlAttribute.new(description, :id) },
+  #   ->(description) { ::LinkThumbnailer::Graders::Position.new(description) },
+  #   ->(description) { ::LinkThumbnailer::Graders::LinkDensity.new(description) }
+  # ]
+
+  # Minimum description length for a website.
+  #
+  # config.description_min_length = 25
+
+  # Regex of words considered positive to rate website description.
+  #
+  config.positive_regex = /article|body|content|entry|hentry|main|page|pagination|post|text|blog|story/i
+
+  # Regex of words considered negative to rate website description.
+  #
+  config.negative_regex = /combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|shoutbox|sidebar|sponsor|shopping|tags|tool|widget|modal/i
+
+  # Numbers of images to fetch. Fetching too many images will be slow.
+  # Note that LinkThumbnailer will only sort fetched images between each other.
+  # Meaning that they could be a "better" image on the page.
+  #
+  config.image_limit = 7
+
+  # Whether you want LinkThumbnailer to return image size and type or not.
+  # Setting this value to false will increase performance since for each images, LinkThumbnailer
+  # does not have to fetch its size and type.
+  #
+  config.image_stats = true
+end

--- a/db/migrate/20150203222133_add_preview_fields_to_material.rb
+++ b/db/migrate/20150203222133_add_preview_fields_to_material.rb
@@ -1,0 +1,6 @@
+class AddPreviewFieldsToMaterial < ActiveRecord::Migration
+  def change
+    add_column :materials, :preview_type, :string
+    add_column :materials, :preview_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141129191015) do
+ActiveRecord::Schema.define(version: 20150203222133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "authorizations", force: true do |t|
+  create_table "authorizations", force: :cascade do |t|
     t.string   "provider"
     t.string   "uid"
     t.integer  "user_id"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 20141129191015) do
 
   add_index "authorizations", ["user_id"], name: "index_authorizations_on_user_id", using: :btree
 
-  create_table "events", force: true do |t|
+  create_table "events", force: :cascade do |t|
     t.string   "name"
     t.datetime "date"
     t.text     "description"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20141129191015) do
   add_index "events", ["slug"], name: "index_events_on_slug", unique: true, using: :btree
   add_index "events", ["user_id"], name: "index_events_on_user_id", using: :btree
 
-  create_table "highlights", force: true do |t|
+  create_table "highlights", force: :cascade do |t|
     t.string   "description"
     t.string   "url"
     t.datetime "start_at"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 20141129191015) do
     t.string   "label",       default: "hamburg"
   end
 
-  create_table "jobs", force: true do |t|
+  create_table "jobs", force: :cascade do |t|
     t.string   "name"
     t.string   "url"
     t.integer  "location_id"
@@ -65,14 +65,14 @@ ActiveRecord::Schema.define(version: 20141129191015) do
 
   add_index "jobs", ["location_id"], name: "index_jobs_on_location_id", using: :btree
 
-  create_table "likes", force: true do |t|
+  create_table "likes", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "topic_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "locations", force: true do |t|
+  create_table "locations", force: :cascade do |t|
     t.string   "name"
     t.string   "url"
     t.string   "street"
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 20141129191015) do
   add_index "locations", ["id"], name: "index_locations_on_id", using: :btree
   add_index "locations", ["slug"], name: "index_locations_on_slug", unique: true, using: :btree
 
-  create_table "materials", force: true do |t|
+  create_table "materials", force: :cascade do |t|
     t.string   "name"
     t.text     "description"
     t.string   "url"
@@ -100,12 +100,14 @@ ActiveRecord::Schema.define(version: 20141129191015) do
     t.integer  "event_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "preview_type"
+    t.string   "preview_code"
   end
 
   add_index "materials", ["event_id"], name: "index_materials_on_event_id", using: :btree
   add_index "materials", ["user_id"], name: "index_materials_on_user_id", using: :btree
 
-  create_table "participants", force: true do |t|
+  create_table "participants", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "event_id"
     t.boolean  "maybe"
@@ -117,7 +119,7 @@ ActiveRecord::Schema.define(version: 20141129191015) do
   add_index "participants", ["event_id"], name: "index_participants_on_event_id", using: :btree
   add_index "participants", ["user_id"], name: "index_participants_on_user_id", using: :btree
 
-  create_table "topics", force: true do |t|
+  create_table "topics", force: :cascade do |t|
     t.string   "name"
     t.text     "description"
     t.integer  "user_id"
@@ -132,7 +134,7 @@ ActiveRecord::Schema.define(version: 20141129191015) do
   add_index "topics", ["event_id"], name: "index_topics_on_event_id", using: :btree
   add_index "topics", ["user_id"], name: "index_topics_on_user_id", using: :btree
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "nickname"
     t.string   "name"
     t.string   "image"

--- a/spec/concerns/preview_generator_spec.rb
+++ b/spec/concerns/preview_generator_spec.rb
@@ -17,8 +17,8 @@ describe "PreviewGenerator" do
 
     it "detects the first embeddable video code" do
 
-      embeddable     = double(embedded_code: "code")
-      non_embeddable = double(embedded_code: nil)
+      embeddable     = double(embed_code: "code")
+      non_embeddable = double(embed_code: nil)
       website        = double(videos: [non_embeddable, embeddable], images: [])
 
       expect(LinkThumbnailer).to receive(:generate).with('http://hey.com').and_return(website)

--- a/spec/concerns/preview_generator_spec.rb
+++ b/spec/concerns/preview_generator_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+describe "PreviewGenerator" do
+
+  it "can be created by an URI" do
+    g = PreviewGenerator.new('http://google.com')
+    expect(g.uri).to eq('http://google.com')
+  end
+
+  context "#generate_preview" do
+
+    it "invokes LinkThumbnailer" do
+      website = double(videos: [], images: [])
+      expect(LinkThumbnailer).to receive(:generate).with('http://hey.com').and_return(website)
+      PreviewGenerator.new('http://hey.com').generate_preview
+    end
+
+    it "detects the first embeddable video code" do
+
+      embeddable     = double(embedded_code: "code")
+      non_embeddable = double(embedded_code: nil)
+      website        = double(videos: [non_embeddable, embeddable], images: [])
+
+      expect(LinkThumbnailer).to receive(:generate).with('http://hey.com').and_return(website)
+
+      pg = PreviewGenerator.new('http://hey.com')
+
+      pg.generate_preview
+
+      expect(pg.video?).to eq(true)
+      expect(pg.image?).to eq(false)
+      expect(pg.type).to eq(:video)
+      expect(pg.code).to eq('code')
+    end
+
+    it "uses the first available image" do
+
+      img            = double(src: "src")
+      website        = double(videos: [], images: [img])
+      expect(LinkThumbnailer).to receive(:generate).with('http://hey.com').and_return(website)
+
+      pg = PreviewGenerator.new('http://hey.com')
+
+      pg.generate_preview
+
+      expect(pg.video?).to eq(false)
+      expect(pg.image?).to eq(true)
+
+      expect(pg.type).to eq(:image)
+      expect(pg.code).to eq('src')
+    end
+
+    it "gives up with no videos nor images" do
+
+      website = double(videos: [], images: [])
+      expect(LinkThumbnailer).to receive(:generate).with('http://hey.com').and_return(website)
+
+      pg = PreviewGenerator.new('http://hey.com')
+
+      pg.generate_preview
+
+      expect(pg.video?).to eq(false)
+      expect(pg.image?).to eq(false)
+      expect(pg.none?).to eq(true)
+
+    end
+
+  end
+
+
+end
+

--- a/spec/helpers/preview_helper_spec.rb
+++ b/spec/helpers/preview_helper_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe PreviewHelper do
+  context "#material_preview" do
+    it "generates nothing if the material has no preview" do
+      material = build(:material)
+      expect(helper.material_preview(material)).to eql("")
+    end
+
+    it "generates nothing if the material has a preview of type :none" do
+      material = build(:material, preview_type: 'none')
+      expect(helper.material_preview(material)).to eql("")
+    end
+
+    it "generates code for videos" do
+      material = build(:material, preview_type: 'video', preview_code: 'embed code')
+      expect(helper.material_preview(material)).to eql('<div class="preview video">embed code</div>')
+    end
+
+    it "generates code for images" do
+      material = build(:material, name: 'hello', url: 'url', preview_type: 'image', preview_code: 'http://a.png')
+      expect(helper.material_preview(material)).to eql('<div class="preview image"><a title="hello" href="url"><img alt="hello" src="http://a.png" /></a></div>')
+    end
+  end
+end

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Material do
+
+  context '#generate_preview' do
+    it 'uses the PreviewGenerator' do
+      material = create(:material, url: 'http://hey.com')
+
+      generator = double(type: 'image', code: 'code')
+      expect(PreviewGenerator).to receive(:new).with('http://hey.com').and_return(generator)
+      expect(generator).to receive(:generate_preview)
+      expect(material).to receive(:save)
+
+      material.generate_preview
+
+      expect(material.preview_type).to eq('image')
+      expect(material.preview_code).to eq('code')
+    end
+  end
+end


### PR DESCRIPTION
This PR allows materials to generate a "preview" using [LinkThumbnailer](https://github.com/gottfrois/link_thumbnailer)

Often the previews are just images, but for the services which support [OpenGraph](http://ogp.me/) it can also generate embedded videos.

Here's how it looks:

![screen shot 2015-02-07 at 17 33 14](https://cloud.githubusercontent.com/assets/63131/6092793/70bb46f4-aeef-11e4-8e96-2e51dd8e3e31.png)

Unfortunately some of the most popular websites (Youtube, Slideshare) don't follow OpenGraph, so you get an image for them instead (I [created an issue in LinkThumbnailer](https://github.com/gottfrois/link_thumbnailer/issues/51) in case there's something else that can be done). Vimeo happens to support it, so it looks very well, generating the embedded video right there. 

The PR adds two db fields to Materials, called `preview_type` and `preview_code` (note that you will need to migrate the db), which are self-filled by the material doing `material.generate_preview`. I didn't know if it would be useful to allow setting up those fields manually too (so if someone wants to add their own youtube embedded code, they could do so manually) so I have left them out. If you think they should be manually-editable, let me know and I will change them.

The preview generation itself is done by a "PreviewGenerator service" (i put it on the 'concerns' folder, but feel free to move it to a `services` folder if that seems more appropiate) and rendered by a new helper.

*NOTE*: this PR includes no "job" or "thread" to generate the previews in the background, but it is compatible with the current source and could be merged in production (the helper just renders nothing if the material does not have the correct preview fields).