### PR TITLE
Show calendar in events index

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
 
   def section_box(name)
     content_tag :section, class: name, id: name do
-      concat content_tag(:h2, content_tag(:i, '', class: "icon icon-#{name}") + t(name))
+      concat content_tag(:h2, content_tag(:i, '', class: "icon icon-#{name}") + t("main.#{name}"))
       yield
     end
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -12,4 +12,14 @@ module EventsHelper
       button_to t("show.attend"), "#", data: {disable: t("show.login_before_attend")}
     end
   end
+
+  def all_events_webcal_link
+    fa_icon('calendar-o') + ' ' +
+    link_to(t('events.webcal'), events_url(format: 'ics', protocol: 'webcal'))
+  end
+
+  def all_events_rss_link
+    fa_icon('rss') + ' ' +
+    link_to(t('events.rss'), events_url(format: 'xml'))
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -14,12 +14,17 @@ module EventsHelper
   end
 
   def all_events_webcal_link
-    fa_icon('calendar-o') + ' ' +
-    link_to(t('events.webcal'), events_url(format: 'ics', protocol: 'webcal'))
+    fa_icon('calendar') + ' ' +
+    link_to(t('events.webcal'), events_url(format: :ics, protocol: "webcal"))
   end
 
   def all_events_rss_link
     fa_icon('rss') + ' ' +
-    link_to(t('events.rss'), events_url(format: 'xml'))
+    link_to(t('events.rss'), events_url(format: :xml))
+  end
+
+  def events_im_attending_link
+    fa_icon('calendar') + ' ' +
+    link_to(t('events.webcal'), calendar_user_url(id: current_user, format: :ics, protocol: "webcal"))
   end
 end

--- a/app/views/events/_materials.slim
+++ b/app/views/events/_materials.slim
@@ -1,5 +1,5 @@
 - if materials.present?
-  h3#materials= t("materials")
+  h3#materials= t("main.materials")
   ul
     - materials.each do |material|
       li

--- a/app/views/events/index.slim
+++ b/app/views/events/index.slim
@@ -7,3 +7,10 @@
     - event.topics.each do |topic|
       li.topic= link_to_topic topic
   = paginate events
+
+  p
+    = t 'events.calendar_html',
+      webcal_link: all_events_webcal_link,
+      rss_link:    all_events_rss_link
+
+

--- a/app/views/events/index.slim
+++ b/app/views/events/index.slim
@@ -8,9 +8,14 @@
       li.topic= link_to_topic topic
   = paginate events
 
-  p
+  p.meta
+    - if signed_in?
+      span.pull-right
+        = t('events.im_attending_html', events_im_attending_link: events_im_attending_link)
+
     = t 'events.calendar_html',
       webcal_link: all_events_webcal_link,
       rss_link:    all_events_rss_link
+
 
 

--- a/app/views/events/index.xml.builder
+++ b/app/views/events/index.xml.builder
@@ -2,9 +2,9 @@ xml.instruct!
 
 xml.rss "version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/" do
  xml.channel do
-   xml.title       "#{I18n.tw('title')} Feed"
+   xml.title       I18n.tw('title')
    xml.link        url_for only_path: false, controller: 'events'
-   xml.description "Aktuelle #{I18n.tw('name')} Events"
+   xml.description I18n.tw('name')
 
    events.each do |event|
      xml.item do

--- a/app/views/events/show.slim
+++ b/app/views/events/show.slim
@@ -6,8 +6,7 @@ section
     span
       = fa_icon('calendar', class: 'fa-fw')
       => link_to l(event.date, format: :long), event_path(event, format: :ics), title: event.name, class: 'ical'
-      - if signed_in?
-        ==> "(#{calendar_link})"
+
     => t("show.hosted_by")
     = link_to_user event.user
   p.meta

--- a/app/views/events/show.slim
+++ b/app/views/events/show.slim
@@ -9,6 +9,7 @@ section
 
     => t("show.hosted_by")
     = link_to_user event.user
+
   p.meta
     = fa_icon('map-marker', class: 'fa-fw')
     - if event.location.present?
@@ -19,7 +20,6 @@ section
 
   == markdown event.description
 
-
   - if event.participants.present?
     h3= t("show.attendees", count: event.limit || 0, participant_count: event.participants.count)
     p= render 'users/list', users: event.users
@@ -28,3 +28,7 @@ section
   = render "materials", materials: event.materials
   - if event.location.present?
     = render 'shared/route', location: event.location
+
+  p= link_to t('home.all_events'), events_path
+
+

--- a/app/views/home/_events.slim
+++ b/app/views/home/_events.slim
@@ -11,6 +11,8 @@
           - current_event.topics.each do |topic|
             li.topic
               = link_to_topic topic
+
+    p = link_to t('home.all_events'), events_path
   - else
     p== I18n.tw("home.next_possible_meetup_recurring", recurring: content_tag(:em, localized_recurring_event_date))
     p== I18n.tw("home.next_possible_meetup", event_date: content_tag(:em, next_event_date))

--- a/app/views/home/_locations.slim
+++ b/app/views/home/_locations.slim
@@ -1,6 +1,6 @@
 = section_box :locations do
   = map(locations)
-  - options = { location_link: link_to(t("locations"), locations_path, title: t("locations")) }
+  - options = { location_link: link_to(t("main.locations"), locations_path, title: t("main.locations")) }
   p== I18n.tw("home.usergroup_locations", options)
   p== I18n.tw("home.company_workers")
   - options = { email_link: mail_to(Whitelabel[:email], "E-Mail", title: "E-Mail"), twitter_link: link_to_twitter(Whitelabel[:twitter]) }

--- a/app/views/shared/_nav.slim
+++ b/app/views/shared/_nav.slim
@@ -6,9 +6,9 @@ nav#nav.navbar
         = link_to image_tag("labels/#{Whitelabel[:label_id]}.png", class: 'label-img', alt: title), '#on_ruby', class: 'label-link'
       - nav_entries.each do |it|
         li
-          = link_to root_path(anchor: it), title: t(it) do
+          = link_to root_path(anchor: it), title: t("main.#{it}") do
             i class="icon icon-#{it}"
-            span.nav-text.hide-phone= t(it)
+            span.nav-text.hide-phone= t("main.#{it}")
       li.dropdown
         - if signed_in?
           = link_to user_path(current_user), {class: 'dropdown-toggle', title: current_user.name} do

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -118,7 +118,6 @@ de:
   event:
     twitter_message: "%{name} am %{date} %{url}"
     recurring: "jeden %{ordinal} %{day} im Monat"
-    subscribe: "meine Events abonieren"
     first: "1."
     second: "2."
     third: "3."
@@ -126,6 +125,7 @@ de:
     last: "letzten"
   events:
     calendar_html: "Kalender: %{webcal_link} - %{rss_link}"
+    im_attending_html: "Meine Events abonieren: %{events_im_attending_link}"
     webcal: 'Webcal'
     rss: 'RSS'
   flash:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -124,6 +124,10 @@ de:
     third: "3."
     fourth: "4."
     last: "letzten"
+  events:
+    calendar_html: "Kalender: %{webcal_link} - %{rss_link}"
+    webcal: 'Webcal'
+    rss: 'RSS'
   flash:
     duplicate_nick: "Der Nickname '%{name}' ist bereits vergeben! Wenn Du Dich schon über einen anderen Provider angemeldet hast, dann trage bitte in Deinem Profil die entsprechenden Handles ein!"
     only_admins: "Hoppala, da dürfen nur Admins hin!"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,4 +1,11 @@
 de:
+  main:
+    events: "Treffen"
+    mailing_list: "Mailinglist"
+    locations: "Orte"
+    people: "Leute"
+    topics: "Themen"
+    materials: "Zusätzliches Material"
   time:
     formats:
       time: "%H:%M"
@@ -12,13 +19,6 @@ de:
     de: "Deutsch"
     en: "Englisch"
     es: "Spanisch"
-  usergroups: "Usergroups"
-  events: "Treffen"
-  mailing_list: "Mailinglist"
-  locations: "Orte"
-  people: "Leute"
-  topics: "Themen"
-  materials: "Zusätzliches Material"
   login:
     profile: "Profil ansehen"
     edit_profile: "Profil bearbeiten"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,11 @@
 en:
+  main:
+    events: "Events"
+    locations: "Locations"
+    mailing_list: "Mailing List"
+    people: "People"
+    topics: "Topics"
+    materials: "Additional Material"
   time:
     formats:
       time: "%H:%M"
@@ -12,13 +19,6 @@ en:
     de: "German"
     en: "English"
     es: "Spanish"
-  usergroups: "Usergroups"
-  events: "Events"
-  mailing_list: "Mailinglist"
-  locations: "Locations"
-  people: "People"
-  topics: "Topics"
-  materials: "Additional Material"
   login:
     profile: "View Profile"
     edit_profile: "Edit Profile"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,6 +123,10 @@ en:
     third: "third"
     fourth: "fourth"
     last: "last"
+  events:
+    calendar_html: "Calendar: %{webcal_link} - %{rss_link}"
+    webcal: 'Webcal'
+    rss: 'RSS'
   flash:
     only_admins: "Ups, only admins allowed!"
     not_authenticated: "Ups, you are not allowed to visit this page!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,6 @@ en:
   event:
     twitter_message: "%{name} at %{date} %{url}"
     recurring: "every %{ordinal} %{day} of the month"
-    subscribe: "subscribe my Events"
     first: "first"
     second: "second"
     third: "third"
@@ -125,6 +124,7 @@ en:
     last: "last"
   events:
     calendar_html: "Calendar: %{webcal_link} - %{rss_link}"
+    im_attending_html: "Events I'm attending: %{events_im_attending_link}"
     webcal: 'Webcal'
     rss: 'RSS'
   flash:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,11 @@
 es:
+  main:
+    events: "Eventos"
+    locations: "Lugares"
+    mailing_list: "Mailing list"
+    people: "Gente"
+    topics: "Temas"
+    materials: "Materiales complementarios"
   time:
     formats:
       time: "%H:%M"
@@ -13,13 +20,6 @@ es:
     de: "Alemán"
     en: "Inglés"
     es: "Español"
-  usergroups: "Grupos de usuarios"
-  events: "Eventos"
-  mailing_list: "Mailing list"
-  locations: "Lugares"
-  people: "Gente"
-  topics: "Temas"
-  materials: "Otros"
   login:
     profile: "Ver perfil"
     edit_profile: "Editar perfil"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -119,7 +119,6 @@ es:
   event:
     twitter_message: "%{name} - %{date} %{url}"
     recurring: "el %{ordinal} %{day} del mes"
-    subscribe: "Subscribirse a todos los eventos"
     first:  "primer"
     second: "segundo"
     third:  "tercer"
@@ -127,6 +126,7 @@ es:
     last:   "último"
   events:
     calendar_html: "Calendario: %{webcal_link} - %{rss_link}"
+    im_attending_html: "Eventos a los que me apunté: %{events_im_attending_link}"
     webcal: 'Webcal'
     rss: 'RSS'
   flash:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -125,6 +125,10 @@ es:
     third:  "tercer"
     fourth: "cuarto"
     last:   "último"
+  events:
+    calendar_html: "Calendario: %{webcal_link} - %{rss_link}"
+    webcal: 'Webcal'
+    rss: 'RSS'
   flash:
     only_admins: "Solamente los administradores pueden entrar ahí"
     not_authenticated: "Por favor autentifícate antes de entrar"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -70,7 +70,7 @@ es:
     usergroup_locations: "Estos son los sitios %{location_link} donde nuestro grupo se ha reunido con anterioridad."
     show_more: "ver más"
     no_new_topics: "Actualmente no hay propuestas, ¡añade tu %{new_topic_link}!"
-    all_events: "Todos los eventos"
+    all_events: "Ver todos los eventos"
     all_people: "Toda la gente"
     to_mailinglist: "A la lista de correo "
     top_maling_entries: "Mensajes recientes"


### PR DESCRIPTION
This is related with #171 . It displays a webcal and rss link at the bottom of the Events#index view, like so:

![screen shot 2015-02-22 at 17 19 54](https://cloud.githubusercontent.com/assets/63131/6319284/0ca99002-bab7-11e4-966c-c80e4e6a1b80.png)

Since I wanted the events-related i18n entries to be inside the `events` namespace, and there was an `events` string entry for the events I moved it (along with all the main "entities") inside a `main` namespace. I hope that's ok.

I also noticed some hardcoded German inside the rss feed. Since this feed is potentially available without logging in (and thus without a locale set up) I decided to change it so that it does not contain any language-specific idioms whatsoever.

EDIT: also moved link "Events I'm attending to" to Events#index (see updated screenshot above). I also added a couple links to "see all events".
