### PR TITLE
full job listion on index page

### DIFF
--- a/app/assets/stylesheets/_modules/icons.sass
+++ b/app/assets/stylesheets/_modules/icons.sass
@@ -13,3 +13,5 @@
   @extend .fa-map-marker
 .icon-bars
   @extend .fa-bars
+.icon-jobs
+  @extend .fa-user

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -29,7 +29,8 @@ module LinkHelper
   end
 
   def job_description(job)
-    t("hint.job_description", city: I18n.tw("city"), job_link: content_tag(:strong, link_to(job.name, job.url, title: job.name)), company_link: link_to_location(job.location))
+    job_description = current_page?(root_url) ? "home.job_description" : "hint.job_description"
+    t(job_description, city: I18n.tw("city"), job_link: content_tag(:strong, link_to(job.name, job.url, title: job.name)), company_link: link_to_location(job.location))
   end
 
   def link_to_location(location)

--- a/app/views/home/_jobs.slim
+++ b/app/views/home/_jobs.slim
@@ -1,0 +1,5 @@
+= section_box :jobs do
+  ul.more-list.clearfix
+    - jobs.each do |job|
+      li
+        == job_description(job)

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -1,4 +1,5 @@
 - render_cached do
+  = render 'jobs', jobs: jobs if jobs.any?
   = render 'events', events: events, current_event: current_event
   = render 'topics', undone_topics: undone_topics, done_topics: done_topics, organizers: organizers
   = render 'people', people: people

--- a/app/views/shared/_hint.slim
+++ b/app/views/shared/_hint.slim
@@ -11,7 +11,7 @@
             .highlights
               strong=> t("hint.attention")
               = link_to highlight.description, highlight.url, title: highlight.description
-  - elsif jobs.present?
+  - elsif jobs.present? && (request.original_fullpath != root_path)
     - unless current_user && current_user.hide_jobs?
       - render_cached(:jobs) do
         #jobs

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -6,6 +6,7 @@ de:
     people: "Leute"
     topics: "Themen"
     materials: "Zusätzliches Material"
+    jobs: "Ruby / Rails Jobs"
   time:
     formats:
       time: "%H:%M"
@@ -76,6 +77,7 @@ de:
     top_maling_entries: "Top Diskussionen"
     goto_maling_list: "Zur Mailinglist"
     mailing_list: "Die Mailinglist ist eine Möglichkeit stets auf dem Laufenden zu bleiben oder sich an Diskussionsthemen zu beteiligen. Sie wird dafür verwendet jeden über Neuigkeiten per E-Mail zu informieren, der sich dafür eingeschrieben hat. Organisatorische, fachliche und andere interessante Dinge werden hier diskutiert und abgestimmt. Keine Werbung - keine Scheu."
+    job_description: "%{job_link} bei %{company_link} in %{city}"
   profile:
     edit: "Profil bearbeiten"
     freelancer: "Freiberufler"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
     people: "People"
     topics: "Topics"
     materials: "Additional Material"
+    jobs: "Ruby / Rails Jobs"
   time:
     formats:
       time: "%H:%M"
@@ -75,6 +76,7 @@ en:
     top_maling_entries: "Top discussions"
     goto_maling_list: "To the Mailinglist"
     mailing_list: "The Mailinglist is a tool to just stay up-to-date or to even get involved in discussions. It is used to inform everyone about News via e-mail who signed up for it. Organizational, technical and other interesting topics are discussed and coordinated here. No ads - no dread."
+    job_description: "%{job_link} at %{company_link} in %{city}"
   profile:
     edit: "Edit profile"
     freelancer: "Freelancer"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6,6 +6,7 @@ es:
     people: "Gente"
     topics: "Temas"
     materials: "Materiales complementarios"
+    jobs: "Trabajos de Ruby o Rails"
   time:
     formats:
       time: "%H:%M"
@@ -76,6 +77,7 @@ es:
     top_maling_entries: "Mensajes recientes"
     goto_maling_list: "A la lista de correo"
     mailing_list: "La lista de correo es una herramienta para estar al tanto de lo que ocurre en el grupo, pero se pueden iniciar conversaciones sobre otros temas. Se utiliza para informar por e-mail a las personas que se registran en ella. Los temas principales que se discuten son de organización, técnicos, o simplemente interesantes. No enviamos anuncios."
+    job_description: "%{job_link} para %{company_link} en %{city}"
 
   profile:
     edit: "Editar perfil"

--- a/spec/views/home/index.html_spec.rb
+++ b/spec/views/home/index.html_spec.rb
@@ -6,12 +6,14 @@ describe "home/index" do
   let(:location)  { build(:location) }
   let(:topic)     { build(:topic) }
   let(:company)   { build(:location, company: true) }
+  let(:job)       { build(:job) }
 
   it "should render successfully" do
     allow(view).to receive_messages(events: [event], current_event: event, people: [user])
     allow(view).to receive_messages(locations: [location], done_topics: [topic])
     allow(view).to receive_messages(undone_topics: [topic], organizers: [user])
     allow(view).to receive_messages(companies: [company], main_user: user, signed_in?: false)
+    allow(view).to receive_messages(jobs: [job])
 
     render
   end


### PR DESCRIPTION
Can we have every job listing displayed on the index page? I didn't like the only one listing solution and the shuffle wasn't working for me. I left the single job listings in place for the other views. 