### PR TITLE
allow custom recurrence

### DIFF
--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -41,7 +41,7 @@ class Usergroup
   end
 
   def localized_recurring
-    return localized_custom_recurring if custom_recurring?
+    return localized_custom_recurrence if custom_recurring
 
     number, day, _ = recurring.split(DELIMITER_DATE)
 
@@ -51,14 +51,10 @@ class Usergroup
     I18n.t("event.recurring", ordinal: ordinal, day: day)
   end
 
-  def custom_recurring?
-    custom_recurring.present?
-  end
-
-  def localized_custom_recurring
-    if custom_recurring?
-      custom_recurring[I18n.locale] || custom_recurring[default_locale.to_sym]
-    end
+  def localized_custom_recurrence
+    recurrence_text = I18n.tw('custom_recurrence')
+    recurrence_text = I18n.tw('custom_recurrence', locale: default_locale) if recurrence_text == 'n/a' # fall back to default locale
+    recurrence_text == 'n/a' ? nil : recurrence_text
   end
 
   def to_s

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -3,7 +3,7 @@ class Usergroup
   DELIMITER_DATE    = ' '
   NUMBERS           = %w(first second third fourth)
 
-  attr_accessor :label_id, :default_locale, :domains, :recurring, :email, :google_group, :coc, :default_time_zone
+  attr_accessor :label_id, :default_locale, :domains, :recurring, :custom_recurring, :email, :google_group, :coc, :default_time_zone
   attr_accessor :twitter, :organizers, :location, :imprint, :other_usergroups, :tld, :sponsors
 
   def parse_recurring_date(date)
@@ -41,12 +41,24 @@ class Usergroup
   end
 
   def localized_recurring
+    return localized_custom_recurring if custom_recurring?
+
     number, day, _ = recurring.split(DELIMITER_DATE)
 
     ordinal = I18n.t("event.#{number}")
     day     = I18n.t('date.day_names')[Date::DAYS_INTO_WEEK[day.to_sym] + 1]
 
     I18n.t("event.recurring", ordinal: ordinal, day: day)
+  end
+
+  def custom_recurring?
+    custom_recurring.present?
+  end
+
+  def localized_custom_recurring
+    if custom_recurring?
+      custom_recurring[I18n.locale] || custom_recurring[default_locale.to_sym]
+    end
   end
 
   def to_s

--- a/app/views/home/_events.slim
+++ b/app/views/home/_events.slim
@@ -13,7 +13,7 @@
               = link_to_topic topic
   - else
     p== I18n.tw("home.next_possible_meetup_recurring", recurring: content_tag(:em, localized_recurring_event_date))
-    - unless Whitelabel[:custom_recurring?]
+    - unless Whitelabel[:custom_recurring]
       p== I18n.tw("home.next_possible_meetup", event_date: content_tag(:em, next_event_date))
 
   - if events.any?

--- a/app/views/home/_events.slim
+++ b/app/views/home/_events.slim
@@ -13,7 +13,8 @@
               = link_to_topic topic
   - else
     p== I18n.tw("home.next_possible_meetup_recurring", recurring: content_tag(:em, localized_recurring_event_date))
-    p== I18n.tw("home.next_possible_meetup", event_date: content_tag(:em, next_event_date))
+    - unless Whitelabel[:custom_recurring?]
+      p== I18n.tw("home.next_possible_meetup", event_date: content_tag(:em, next_event_date))
 
   - if events.any?
     h3= t("home.past_events")

--- a/config/locales/de.label.yml
+++ b/config/locales/de.label.yml
@@ -6,6 +6,7 @@ de:
       title: OnRuby - Die Ruby und Rails Usergroup Plattform
       subtitle: Ruby / Rails Communities Deutschland
       meta_desc: Ruby / Rails Communities Deutschland
+      custom_recurrence: n/a
     hamburg:
       city: Hamburg
       name: Ruby Usergroup Hamburg
@@ -30,6 +31,7 @@ de:
       title: Cologne.rb
       subtitle: Ruby User Group Cologne
       meta_desc: Ruby / Rails User Group Cologne
+      custom_recurrence: "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
     saar:
       city: Saarland
       name: RUGSaar

--- a/config/locales/en.label.yml
+++ b/config/locales/en.label.yml
@@ -6,6 +6,7 @@ en:
       title: OnRuby - The Ruby and Rails usergroup platform
       subtitle: Ruby / Rails Communities Germany
       meta_desc: Ruby / Rails Communities Germany
+      custom_recurrence: n/a
     hamburg:
       city: Hamburg
       name: Ruby Usergroup Hamburg
@@ -30,6 +31,7 @@ en:
       title: Cologne.rb
       subtitle: Ruby User Group Cologne
       meta_desc: Ruby / Rails User Group Cologne
+      custom_recurrence: "every 3rd Wednesday in every second month (January, March, May, July, September, November)"
     saar:
       city: Saarland
       name: RUGSaar

--- a/config/locales/es.label.yml
+++ b/config/locales/es.label.yml
@@ -6,6 +6,7 @@ es:
       title: OnRuby - Plataforma de grupos de usuarios de Ruby y Rails
       subtitle: Comunidades de Ruby / Rails
       meta_desc: Comunidades de Ruby / Rails
+      custom_recurrence: n/a
     hamburg:
       city: Hamburgo
       name: Ruby Usergroup Hamburg

--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -90,6 +90,9 @@
   label_id: cologne
   default_locale: de
   recurring: third wednesday
+  custom_recurring:
+    :de: "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
+    :en: "every 3rd Wednesday in every second month (January, March, May, July, September, November)"
   email: colognerb@googlegroups.com
   twitter: colognerb
   organizers:

--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -90,9 +90,7 @@
   label_id: cologne
   default_locale: de
   recurring: third wednesday
-  custom_recurring:
-    :de: "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
-    :en: "every 3rd Wednesday in every second month (January, March, May, July, September, November)"
+  custom_recurring: true
   email: colognerb@googlegroups.com
   twitter: colognerb
   organizers:

--- a/spec/models/usergroup_spec.rb
+++ b/spec/models/usergroup_spec.rb
@@ -66,37 +66,37 @@ describe Usergroup do
     end
   end
 
-  context '#custom_recurring?' do
+  context '#custom_recurring' do
     specify do
-      expect(colognerb.custom_recurring?).to eql true
-      expect(rughh.custom_recurring?).to eql false
+      expect(colognerb.custom_recurring).to eql true
+      expect(rughh.custom_recurring).to eql nil
     end
   end
 
-  context '#localized_custom_recurring' do
+  context '#localized_custom_recurrence' do
     context 'no custom recurring' do
       it 'should return nil' do
-        expect(rughh.custom_recurring?).to eql false
+        expect(rughh.localized_custom_recurrence).to eql nil
       end
     end
 
     context 'with custom recurring' do
       specify 'de' do
         I18n.with_locale(:de) do
-          expect(colognerb.localized_custom_recurring).to eql "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
+          expect(colognerb.localized_custom_recurrence).to eql "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
         end
       end
 
       specify 'en' do
         I18n.with_locale(:en) do
-          expect(colognerb.localized_custom_recurring).to eql "every 3rd Wednesday in every second month (January, March, May, July, September, November)"
+          expect(colognerb.localized_custom_recurrence).to eql "every 3rd Wednesday in every second month (January, March, May, July, September, November)"
         end
       end
 
       context 'translation for locale is missing (> es)' do
         it 'should fall back to default_locale of Whitelabel (> de)' do
           I18n.with_locale(:es) do
-            expect(colognerb.localized_custom_recurring).to eql "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
+            expect(colognerb.localized_custom_recurrence).to eql "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
           end
         end
       end

--- a/spec/models/usergroup_spec.rb
+++ b/spec/models/usergroup_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Usergroup do
   let(:every_second_wednesday) { Usergroup.new.tap { |it| it.recurring = 'second wednesday 18:30' } }
   let(:every_last_wednesday)   { Usergroup.new.tap { |it| it.recurring = 'last wednesday 18:30' } }
+  let(:rughh) { Whitelabel.label_for("hamburg") }
+  let(:colognerb) { Whitelabel.label_for("cologne") }
 
   context "parsing of recurring" do
     context "as string" do
@@ -13,8 +15,6 @@ describe Usergroup do
     end
 
     context "as date/time" do
-      let(:rughh) { Whitelabel.label_for("hamburg") }
-      let(:colognerb) { Whitelabel.label_for("cologne") }
       let(:hackhb) { Whitelabel.label_for("bremen") }
       let(:karlsruhe) { Whitelabel.label_for("karlsruhe")}
       let(:_1830) { Usergroup.new.tap { |it| it.recurring = 'second wednesday 18:30' } }
@@ -61,6 +61,43 @@ describe Usergroup do
           parsed_time = rughh.parse_recurring_time
           expect(parsed_time.hour).to eql(18)
           expect(parsed_time.min).to eql(30)
+        end
+      end
+    end
+  end
+
+  context '#custom_recurring?' do
+    specify do
+      expect(colognerb.custom_recurring?).to eql true
+      expect(rughh.custom_recurring?).to eql false
+    end
+  end
+
+  context '#localized_custom_recurring' do
+    context 'no custom recurring' do
+      it 'should return nil' do
+        expect(rughh.custom_recurring?).to eql false
+      end
+    end
+
+    context 'with custom recurring' do
+      specify 'de' do
+        I18n.with_locale(:de) do
+          expect(colognerb.localized_custom_recurring).to eql "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
+        end
+      end
+
+      specify 'en' do
+        I18n.with_locale(:en) do
+          expect(colognerb.localized_custom_recurring).to eql "every 3rd Wednesday in every second month (January, March, May, July, September, November)"
+        end
+      end
+
+      context 'translation for locale is missing (> es)' do
+        it 'should fall back to default_locale of Whitelabel (> de)' do
+          I18n.with_locale(:es) do
+            expect(colognerb.localized_custom_recurring).to eql "jeweils am 3. Mittwoch in jedem 2. Monat (Januar, März, Mai, Juli, September, November) um 19:00 Uhr"
+          end
         end
       end
     end


### PR DESCRIPTION
for complicated cases, allow a usergroup to specify a custom recurrence using a translated string, which will be displayed on the homepage instead of a calculated next event date.