### PR TITLE
upcoming topics should not appear as 'Recent Topics'

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,7 @@ class HomeController < ApplicationController
   expose(:events)         { Event.latest.limit(10) }
   expose(:people)         { User.peers }
   expose(:undone_topics)  { Topic.ordered.undone }
+  expose(:upcoming_topics){ Topic.ordered.upcoming }
   expose(:done_topics)    { Topic.ordered.done.limit(10) }
   expose(:organizers)     { User.organizers }
   expose(:locations)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -6,6 +6,7 @@ class TopicsController < ApplicationController
   expose(:events)         { Event.with_topics.ordered.page(params[:page]).per(10) }
   expose(:undone_topics)  { Topic.ordered.undone }
   expose(:done_topics)    { Topic.ordered.done }
+  expose(:upcoming_topics){ Topic.ordered.upcoming }
 
   def index; end
   def show; end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -16,9 +16,10 @@ class Topic < ActiveRecord::Base
 
   has_many :likes, dependent: :destroy
 
-  scope :ordered, -> { order('created_at DESC') }
-  scope :undone,  -> { where('event_id IS NULL') }
-  scope :done,    -> { where('event_id IS NOT NULL') }
+  scope :ordered,  -> { order('created_at DESC') }
+  scope :undone,   -> { where('event_id IS NULL') }
+  scope :done,     -> { joins(:event).where('date <= ?', Time.now - 2.hour) }
+  scope :upcoming, -> { joins(:event).where('date > ?', Time.now - 2.hour) }
 
   default_scope -> { where(label: Whitelabel[:label_id]) }
 

--- a/app/views/home/_topics.slim
+++ b/app/views/home/_topics.slim
@@ -7,5 +7,6 @@
   = render 'users/list', users: organizers
   p== I18n.tw("home.engage")
   = button_to t("home.add_topic"), new_topic_path, method: :get
+  = render 'topics/upcoming', topics: upcoming_topics
   = render 'topics/undone', topics: undone_topics
   = render 'topics/done', topics: done_topics

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -1,6 +1,6 @@
 - render_cached do
   = render 'events', events: events, current_event: current_event
-  = render 'topics', undone_topics: undone_topics, done_topics: done_topics, organizers: organizers
+  = render 'topics', undone_topics: undone_topics, done_topics: done_topics, upcoming_topics: upcoming_topics, organizers: organizers
   = render 'people', people: people
   = render 'mailing_list'
   = render 'locations', locations: locations

--- a/app/views/topics/_upcoming.slim
+++ b/app/views/topics/_upcoming.slim
@@ -1,0 +1,7 @@
+- if topics.present?
+  #upcoming
+    h3= t('home.upcoming_topics')
+    ul.more-list.clearfix
+      - topics.each do |topic|
+        li.topic
+          = link_to_topic topic

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -58,6 +58,7 @@ de:
     engage: "Usergroups leben von Vorträgen und dem Engagement der Teilnehmer. Wenn du ein Thema vermisst, oder nähre Informationen zu speziellen Bereichen suchst, dann <strong>kannst du hier gerne etwas in die Wunschliste eintragen</strong>. Solltest du schon eine Idee zu einem Vortrag oder ähnlichem haben, dann <strong>kannst du ihn hier eintragen</strong>, um Feedback von der Ruby / Rails Community zu bekommen."
     add_topic: "Eigenes Thema eintragen"
     new_topics: "Themenvorschläge"
+    upcoming_topics: "Demnächst vorgestellte Themen"
     old_topics: "Kürzlich vorgestellte Themen"
     company_workers: "Viele der Teilnehmer an der Ruby Usergroup arbeiten auch dort und wir freuen uns immer über neue Gesichter."
     company_missing: "Solltest du eine Firma vermissen, dann schicke uns einfach eine %{email_link} oder Direct-Message an %{twitter_link}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
     engage: "Usergroups need engaging People. If you think some Topic is missing, or you want to have more Infos on something, <strong>you are encouraged to add it to our Wishlist</strong>. If you have an Idea for a Talk or anything else <strong>add it here</strong> to get instant Feedback of the Ruby / Rails Community."
     add_topic: "Add a Topic"
     new_topics: "Proposals"
+    upcoming_topics: "Upcoming Topics"
     old_topics: "Recent Topics"
     company_workers: "A lot of the Members of the Ruby Usergroup are working there too and we love to see new faces around."
     company_missing: "If you think that a Company is missing, send us an %{email_link} or Direct-Message to %{twitter_link}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -58,6 +58,7 @@ es:
     engage: "Los grupos de usuarios necesitan interacción. Si crees que estaría bien dar una charla sobre un Tema, o quieres profundizar sobre alguno, <strong>por favor añádelo en nuestra Wishlist</strong>. Si tienes una idea para una charla o actividad <strong>proponla aquí</strong> para obtener feedback de la comunidad de Ruby/Rails."
     add_topic: "Proponer un Tema"
     new_topics: "Propuestas"
+    upcoming_topics: "Próximos temas"
     old_topics: "Temas recientes"
     company_workers: "En ocasiones serán lugares de trabajo de los miembros del Grupo de Usuarios; esto es normal, y les encanta ver caras nuevas."
     company_missing: "Si crees que falta una compañía, envíanos un %{email_link} o un tweet a %{twitter_link}"

--- a/spec/views/home/index.html_spec.rb
+++ b/spec/views/home/index.html_spec.rb
@@ -10,7 +10,7 @@ describe "home/index" do
   it "should render successfully" do
     allow(view).to receive_messages(events: [event], current_event: event, people: [user])
     allow(view).to receive_messages(locations: [location], done_topics: [topic])
-    allow(view).to receive_messages(undone_topics: [topic], organizers: [user])
+    allow(view).to receive_messages(undone_topics: [topic], organizers: [user], upcoming_topics: [topic])
     allow(view).to receive_messages(companies: [company], main_user: user, signed_in?: false)
 
     render


### PR DESCRIPTION
If a topic is assigned to an event, the topic currently appears under 'Recent Topics' even if the event is in the future. In my opinion, this is misleading since the topic has not been presented yet.

This pull request adds another subsection for upcoming topics to the 'Topics' section. What do you think about this? In particular:

* Is the extra subsection 'Upcoming Topics' reasonable, or should we merge the upcoming topics into the existing 'Proposals' subsection? 

* What about the order of subsections? This code uses 'Upcoming Topics', 'Proposals', 'Recent Topics' - but we might as well go for 'Proposals', 'Upcoming Topics', 'Recent Topics'.

* I had to use google translate for the spanish translation - can anyone who speaks spanish double check the wording?

The implemantion relies on joining db tables, but given the tiny size of our tables I do not expect this to be an issue.