### PR TITLE
Add slackin to the index page and also to the people section

### DIFF
--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -87,4 +87,8 @@ module ExternalLinkHelper
       end
     end
   end
+
+  def slackin_js_url
+    "#{Whitelabel[:slackin_url]}/slackin.js" if Whitelabel[:slackin_url]
+  end
 end

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -4,7 +4,7 @@ class Usergroup
   NUMBERS           = %w(first second third fourth)
 
   attr_accessor :label_id, :default_locale, :domains, :recurring, :custom_recurring, :email, :google_group, :coc, :default_time_zone
-  attr_accessor :twitter, :organizers, :location, :imprint, :other_usergroups, :tld, :sponsors
+  attr_accessor :twitter, :organizers, :location, :imprint, :other_usergroups, :tld, :sponsors, :slackin_url
 
   def parse_recurring_date(date)
     number, day, _ = recurring.split(DELIMITER_DATE)

--- a/app/views/home/_people.slim
+++ b/app/views/home/_people.slim
@@ -1,3 +1,5 @@
 = section_box :people do
   p== I18n.tw("home.the_usergroup", usergroup: I18n.tw("name"))
   = render 'users/list', users: people
+  - if slackin_js_url
+    script src=slackin_js_url async defer

--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -241,6 +241,7 @@
       :email: leipzigonrails@googlegroups.com
   tld: de
   google_group: leipzigonrails
+  slackin_url: http://slack-onruby.herokuapp.com/
 - !ruby/object:Usergroup
   label_id: dresden
   default_locale: de


### PR DESCRIPTION
We have now one slack group for all onruby members/groups. I added a
invite box/badge, provided by slackin, to the application because it's only
possible to join the slack group by an invite.

![screen shot 2015-10-22 at 12 33 21](https://cloud.githubusercontent.com/assets/419651/10663228/2dc9e6c6-78ba-11e5-9abd-2dcceca9fba1.png)