### PR TITLE
Increase search period for current event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,7 +22,7 @@ class Event < ActiveRecord::Base
   default_scope       -> { where(label: Whitelabel[:label_id]) }
 
   scope :with_topics, -> { joins(:topics).uniq }
-  scope :current,     -> { where(date: Date.today.to_time..(Time.now + 8.weeks)).limit(1).order('date ASC') }
+  scope :current,     -> { where(date: Date.today.to_time..(Time.now + 9.weeks)).limit(1).order('date ASC') }
   scope :latest,      -> { where('date < ?', Date.today.to_time).order('date DESC') }
   scope :unpublished, -> { where("published = ? OR published = ?", nil, false) }
   scope :ordered,     -> { order("date DESC") }


### PR DESCRIPTION
In Cologne we have bi-monthly meetups and the next event (on January 20 http://www.colognerb.de/events/januar-2016-meetup) is currently not yet displayed on our homepage http://www.colognerb.de/ because the search period is too short. This should fix that.

Thanks.