### PR TITLE
make url editable

### DIFF
--- a/app/views/users/edit.slim
+++ b/app/views/users/edit.slim
@@ -9,6 +9,7 @@ section
     - unless user.with_provider? :github
         = f.input :github, input_html: { placeholder: 'GitHub handle' }
     = f.input :email
+    = f.input :url
     = f.input :description, type: :text_area
     .info== t("topic.markdown")
     br


### PR DESCRIPTION
I just found out that my url is not editable. I added the field to the form. 

Warning: I could not test it this morning because I could not setup the twitter / github login locally. 