### PR TITLE
Add .ruby-version file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ cache
 spec/reports/
 .vagrant
 Vagrantfile
+.ruby-version
 .ruby-gemset
 passenger.*


### PR DESCRIPTION
`.ruby-gemset` is already ignored and the repository doesn't itself contain `.ruby-version` file. I believe that it makes sense to ignore `.ruby-version` file as well.