### PR TITLE
actually make the country dynamic

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -16,7 +16,11 @@ class Location < ActiveRecord::Base
   default_scope   -> { where(label: Whitelabel[:label_id]) }
 
   def geo_coder_address
-    "#{street} #{house_number}, #{zip} #{city}, #{I18n.t('countries.DE')}"
+    "#{street} #{house_number}, #{zip} #{city}, #{country}"
+  end
+
+  def country
+    Whitelabel.find_label(self.label).country
   end
 
   def address

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -5,7 +5,7 @@ class Usergroup
 
   attr_accessor :label_id, :default_locale, :domains, :recurring, :custom_recurring, :email, :google_group, :coc
   attr_accessor :default_time_zone, :twitter, :organizers, :location, :imprint, :other_usergroups, :tld
-  attr_accessor :sponsors, :slackin_url
+  attr_accessor :sponsors, :slackin_url, :country
 
   def parse_recurring_date(date)
     number, day, = recurring.split(DELIMITER_DATE)
@@ -86,6 +86,7 @@ class Usergroup
       it.label_id = it.google_group = it.twitter = name.underscore
       it.default_locale   = 'de'
       it.tld              = 'de'
+      it.country          = 'Deutschland'
       it.domains          = ["#{name.parameterize}.de"]
       it.recurring        = 'second wednesday'
       it.email            = "info@#{name.parameterize}.de"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -11,9 +11,6 @@ de:
       time: "%H:%M"
       date: "%d.%m. %H:%M"
       month: "%B %Y"
-  countries:
-    DE: "Deutschland"
-    ES: "Spanien"
   switch_languages: "Umschalten auf %{language}"
   languages:
     de: "Deutsch"

--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -2,6 +2,7 @@
 - !ruby/object:Usergroup
   label_id: hamburg
   default_locale: de
+  country: Deutschland
   recurring: second wednesday
   email: hamburg@onruby.de
   twitter: hamburgsync
@@ -60,6 +61,7 @@
 - !ruby/object:Usergroup
   label_id: cologne
   default_locale: de
+  country: Deutschland
   recurring: third wednesday
   email: colognerb@googlegroups.com
   twitter: colognerb
@@ -105,6 +107,7 @@
 - !ruby/object:Usergroup
   label_id: saar
   default_locale: de
+  country: Deutschland
   recurring: second friday 18:30
   email: rug.saar@gmail.com
   twitter: RUGSaar
@@ -135,6 +138,7 @@
 - !ruby/object:Usergroup
   label_id: karlsruhe
   default_locale: de
+  country: Deutschland
   recurring: third wednesday
   email: karlsruherb@googlegroups.com
   twitter: rug_ka
@@ -166,6 +170,7 @@
 - !ruby/object:Usergroup
   label_id: berlin
   default_locale: en
+  country: Deutschland
   recurring: first thursday 19:30
   email: rug-b@googlegroups.com
   twitter: rug_b
@@ -194,6 +199,7 @@
 - !ruby/object:Usergroup
   label_id: leipzig
   default_locale: de
+  country: Deutschland
   recurring: third thursday 19:00
   email: leipzigonrails@googlegroups.com
   twitter: LeipzigOnRails
@@ -220,6 +226,7 @@
 - !ruby/object:Usergroup
   label_id: dresden
   default_locale: de
+  country: Deutschland
   recurring: first thursday 19:00
   email: admin@ruby-dresden.de
   twitter: ruby_dresden
@@ -251,6 +258,7 @@
 - !ruby/object:Usergroup
   label_id: railsgirlshh
   default_locale: de
+  country: Deutschland
   recurring: fourth wednesday 19:30
   email: railsgirlshh@gmail.com
   twitter: railsgirlshh
@@ -307,6 +315,7 @@
 - !ruby/object:Usergroup
   label_id: bonn
   default_locale: de
+  country: Deutschland
   recurring: second monday
   email: bonnrb@googlegroups.com
   twitter: bonnrb
@@ -336,6 +345,7 @@
 - !ruby/object:Usergroup
   label_id: innsbruck
   default_locale: en
+  country: Österreich
   recurring: second saturday
   email: innsbruck.rb@gmail.com
   twitter: innsbruckrb
@@ -361,6 +371,7 @@
 - !ruby/object:Usergroup
   label_id: madridrb
   default_locale: es
+  country: Espania
   recurring: last thursday 19:30
   email: hello@madridrb.com
   twitter: madridrb
@@ -412,6 +423,7 @@
 - !ruby/object:Usergroup
   label_id: munich
   default_locale: de
+  country: Deutschland
   recurring: second wednesday
   email: Munich-Rubyshift-Ruby-User-Group-list@meetup.com
   twitter: muc_rubyshift

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -4,6 +4,7 @@ describe Location do
   before(:each) do
     @location       = create(:location, name: 'Test-Location', street: 'Schanzenstr.', house_number: '85', zip: '20357', city: 'Hamburg')
     @other_location = create(:location, label: 'cologne')
+    @es_location    = create(:location, label: 'madridrb')
   end
 
   context 'validation' do
@@ -23,13 +24,17 @@ describe Location do
       hamburg_locations = Location.all
       expect(hamburg_locations).to have(1).elements
       expect(hamburg_locations.first).to eql(@location)
-      expect(Location.unscoped.size).to be(2)
+      expect(Location.unscoped.size).to be(3)
     end
   end
 
   context '#geo_coder_address' do
     it 'should return a full address string with street, house_number, zip, city and internationalized country name' do
       expect(@location.geo_coder_address).to eq('Schanzenstr. 85, 20357 Hamburg, Deutschland')
+    end
+
+    it 'fetches country names by label' do
+      expect(@es_location.country).to eq('Espania')
     end
   end
 

--- a/spec/support/factories/locations.rb
+++ b/spec/support/factories/locations.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :location do
+    label           { 'hamburg' }
     name            { Faker::Name.name }
     url             { Faker::Internet.url }
     street          { Faker::Address.street_name }


### PR DESCRIPTION
looking at the [current madridrb](http://www.madridrb.com/events/septiembre-2017-409) event i noticed that the location was off on the map.

digging around a bit i noticed that 

* we have an issue with reaching the API limit for geo-coder (have not investigated why)
* there is static data when creating the geocoding address

i fixed the latter, so we can actually geo-code none german locations properly.