### PR TITLE
docs: correct descriptions for scheduler rake tasks

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,5 +1,5 @@
-desc "update geocoding"
 namespace :scheduler do
+  desc "update geocoding"
   task update_geocoding: :environment do
     with_tracking do
       puts "updating all geocoding"
@@ -13,6 +13,7 @@ namespace :scheduler do
     end
   end
 
+  desc "update previews"
   task update_preview: :environment do
     with_tracking do
       puts "updating previews"


### PR DESCRIPTION
I've noticed a small issue with the descriptions within the scheduler rake tasks file

now both tasks will also be listed then listing rake tasks:
```bash
# rake -T
[...]
rake scheduler:update_geocoding         # update geocoding
rake scheduler:update_preview           # update previews
[...]
```