### PR TITLE
Disable creating users from the admin

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,2 +1,5 @@
 class Admin::UsersController < Admin::ResourcesController
+  def new
+    redirect_to url_for(controller: '/admin/users'), notice: "You can't create users via the admin, they need to signup via OAuth!"
+  end
 end

--- a/app/extensions/typus/authentication/custom.rb
+++ b/app/extensions/typus/authentication/custom.rb
@@ -8,6 +8,11 @@ module Typus
 
       def authenticate
         @admin_user = FakeUser.new
+        def @admin_user.can?(*args)
+          action, type, _ = args
+          return false if action == 'create' && type == 'User'
+          return true
+        end
         authenticate_admin_user!
       end
     end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Admin::UsersController do
+  context 'as admin' do
+    before do
+      allow(controller).to receive_messages(current_user: build(:admin_user))
+    end
+
+    it 'renders the index template' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+
+    context 'GET :new' do
+      it 'hides this page' do
+        get :new
+
+        expect(response).to be_a_redirect
+      end
+    end
+
+    context 'POST :create' do
+      it 'hides this page' do
+        post :create, {user: {}}
+
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+end


### PR DESCRIPTION
in order to fix #291 this 

a) hides the user creation action by overwriting the new action in the users admin controller
b) hardcodes the rule the user create action is disallowed

/cc @emrox 