### PR TITLE
remove unused usergroups

### DIFF
--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -5,7 +5,7 @@ class Usergroup
 
   attr_accessor :label_id, :default_locale, :domains, :recurring, :custom_recurring, :email, :google_group, :coc
   attr_accessor :default_time_zone, :twitter, :organizers, :location, :imprint, :other_usergroups, :tld
-  attr_accessor :sponsors, :slackin_url, :country
+  attr_accessor :sponsors, :slackin_url, :country, :status
 
   def parse_recurring_date(date)
     number, day, = recurring.split(DELIMITER_DATE)
@@ -57,6 +57,10 @@ class Usergroup
     # fall back to default locale
     recurrence_text = I18n.tw('custom_recurrence', locale: default_locale) if recurrence_text == 'n/a'
     recurrence_text == 'n/a' ? nil : recurrence_text
+  end
+
+  def enabled?
+    status == 'enabled'
   end
 
   def to_s

--- a/app/views/labels/index.slim
+++ b/app/views/labels/index.slim
@@ -4,8 +4,9 @@ section
 section
   ul
     - Whitelabel.labels.each do |label|
-      li
-        - name = t("label.#{label.label_id}.name")
-        = link_to label_url(label), title: name do
-          span.image = image_tag("labels/#{label.label_id}.png", alt: name)
-          span.host  = name
+      - if label.enabled?
+        li
+          - name = t("label.#{label.label_id}.name")
+          = link_to label_url(label), title: name do
+            span.image = image_tag("labels/#{label.label_id}.png", alt: name)
+            span.host  = name

--- a/app/views/shared/_footer.slim
+++ b/app/views/shared/_footer.slim
@@ -47,10 +47,11 @@ section.clearfix
     h2= t("footer.ruby_usergroups")
     ol.clearfix
       - Whitelabel.labels.each do |label|
-        li
-          - name = t("label.#{label.label_id}.name")
-          => link_to name, label_url(label), title: name
-          = link_to_twitter(label.twitter, clung: true)
+        -if label.enabled?
+          li
+            - name = t("label.#{label.label_id}.name")
+            => link_to name, label_url(label), title: name
+            = link_to_twitter(label.twitter, clung: true)
 
   .railssupporters.block
     h2= t("footer.ruby_supporters")

--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -1,6 +1,7 @@
 ---
 - !ruby/object:Usergroup
   label_id: hamburg
+  status: enabled
   default_locale: de
   country: Deutschland
   recurring: second wednesday
@@ -60,6 +61,7 @@
   coc: http://rubyberlin.github.io/code-of-conduct
 - !ruby/object:Usergroup
   label_id: cologne
+  status: enabled
   default_locale: de
   country: Deutschland
   recurring: third wednesday
@@ -169,6 +171,7 @@
   google_group: karlsruherb
 - !ruby/object:Usergroup
   label_id: berlin
+  status: enabled
   default_locale: en
   country: Deutschland
   recurring: first thursday 19:30
@@ -198,6 +201,7 @@
   slackin_url: http://slack.rubyberlin.org/slackin.js
 - !ruby/object:Usergroup
   label_id: leipzig
+  status: enabled
   default_locale: de
   country: Deutschland
   recurring: third thursday 19:00
@@ -370,6 +374,7 @@
   google_group: innsbruck-rb
 - !ruby/object:Usergroup
   label_id: madridrb
+  status: enabled
   default_locale: es
   country: Espania
   recurring: last thursday 19:30
@@ -411,7 +416,6 @@
   - :name: jobandtalent
     :url: http://www.jobandtalent.com/
     :banner: jobandtalent.png
-
   other_usergroups:
   - :name: Betabeers
     :url: https://betabeers.com/

--- a/readme.md
+++ b/readme.md
@@ -10,16 +10,8 @@ Source for the Sites of the Ruby Communities:
 
 * [Hamburg](http://hamburg.onruby.de)
 * [Cologne](http://cologne.onruby.de)
-* [Saarland](http://saar.onruby.de)
 * [Berlin](http://www.rug-b.de)
-* [Leipzig](http://leipzig.onruby.de)
-* [Karlsruhe](http://karlsruhe.onruby.de)
-* [Dresden](http://dresden.onruby.de)
-* [Railsgirls Hamburg](http://railsgirlshh.onruby.de)
-* [Bonn](http://bonn.onruby.de)
-* [Innsbruck](http://innsbruck.onruby.at)
 * [Madrid](http://madridrb.onruby.eu)
-* [Munich](http://munich.onruby.de)
 
 ## Installation
 
@@ -67,9 +59,7 @@ script/in_docker bundle exec rspec spec/requests/labels_spec.rb
 Add all supported subdomains to your `/etc/hosts` file:
 
 ```
-127.0.0.1    www.onruby.dev hamburg.onruby.dev cologne.onruby.dev saar.onruby.dev
-127.0.0.1    berlin.onruby.dev karlsruhe.onruby.dev leipzig.onruby.dev dresden.onruby.dev
-127.0.0.1    railsgirlshh.onruby.dev bonn.onruby.dev madridrb.onruby.dev munich.onruby.dev
+127.0.0.1    www.onruby.dev hamburg.onruby.dev cologne.onruby.dev berlin.onruby.dev madridrb.onruby.dev
 ```
 
 #### Visit the site
@@ -111,9 +101,7 @@ For working with the whitelabel functionality, you need to add all supported
 subdomains to your `/etc/hosts`:
 
 ```
-127.0.0.1    www.onruby.dev hamburg.onruby.dev cologne.onruby.dev saar.onruby.dev
-127.0.0.1    berlin.onruby.dev karlsruhe.onruby.dev leipzig.onruby.dev dresden.onruby.dev
-127.0.0.1    railsgirlshh.onruby.dev bonn.onruby.dev madridrb.onruby.dev munich.onruby.dev
+127.0.0.1    www.onruby.dev hamburg.onruby.dev cologne.onruby.dev berlin.onruby.dev madridrb.onruby.dev
 ```
 
 Access via [http://www.onruby.dev:5000](http://www.onruby.dev:5000)


### PR DESCRIPTION
as i'm currentyl phasing out the onruby.at domain, i noticed that insbruck has never once scheduled a meetup. 

looking through some of the other usergroups it looks like they are not using unruby any longer or are completely gone.

because of this i added a status, disabling all groups that did not have once scheduled an event within 2017.