### PR TITLE
sanitize html in markdown content

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,6 +73,6 @@ module ApplicationHelper
   private
 
   def markdown_parser
-    @markdown_parser ||= Redcarpet::Markdown.new Redcarpet::Render::HTML, autolink: true, space_after_headers: true
+    @markdown_parser ||= Redcarpet::Markdown.new Redcarpet::Render::Safe, autolink: true, space_after_headers: true
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -25,5 +25,10 @@ describe ApplicationHelper do
     it 'autolinks' do
       expect(helper.markdown('auto http://href.org')).to match('auto <a href="http://href.org">http://href.org</a>')
     end
+
+    it 'escapes html tags' do
+      expect(helper.markdown('<script>alert("xss");</script>'))
+        .to include('&lt;script&gt;alert(&quot;xss&quot;);&lt;/script&gt;')
+    end
   end
 end


### PR DESCRIPTION
Currently user input in the user profile description is not sanitized and allows arbitrary HTML including script tags.