### PR TITLE
Use plural for location link in en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,7 +67,7 @@ en:
     takes_place: "is taking place on %{event_date} at %{location_link}!"
     takes_place_no_location: "is taking place on %{event_date} and still <a href='%{none_url}'>looking for a location!</a>!"
     past_events: "Past events"
-    usergroup_locations: "This is the %{location_link} our usergroup takes place usually."
+    usergroup_locations: "These are the %{location_link} our usergroup usually takes place."
     show_more: "show more"
     no_new_topics: "Currently no proposals, add your %{new_topic_link} here!"
     all_events: "All Events"


### PR DESCRIPTION
Just a minor text improvement.