### PR TITLE
Fix docker port binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ box:
 web:
   build: .
   ports:
-    - "5000:5000"
+    - "3000:3000"
   links:
     - postgres
   volumes:

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,7 @@ Install [Docker and Docker Compose](https://docs.docker.com/compose/install/)
 if you haven't already. Then:
 
 ```sh
-docker-compose build
-docker-compose up
+docker-compose up --build
 ```
 
 > `sudo` might be required for `docker-compose` if you run Docker locally on Linux.

--- a/script/open
+++ b/script/open
@@ -1,1 +1,0 @@
-open "http://hamburg.$(docker-machine active | xargs docker-machine ip).xip.io:5000"


### PR DESCRIPTION
the Dockerfile was outdated and did not bind to the proper port of puma 3000

with the proper etc hosts settings i was able to load `http://hamburg.onruby.test:3000/` from the docker image.

`docker ps` should show that everything is up and running

```
→ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
b14a5d553f0e        on_ruby_web         "/bin/sh -c script/s…"   3 minutes ago       Up 3 minutes        0.0.0.0:3000->3000/tcp   on_ruby_web_1
7d02676cf2e4        postgres:9.4.1      "/docker-entrypoint.…"   7 minutes ago       Up 3 minutes        5432/tcp                 on_ruby_postgres_1
```

closes #457 