### PR TITLE
LinkedIn Field and tests added

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,6 +36,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:twitter, :github, :email, :name, :description, :freelancer, :available, :hide_jobs, :participants, :image, :url)
+    params.require(:user).permit(:twitter, :github, :linkedin, :email, :name, :description, :freelancer, :available, :hide_jobs, :participants, :image, :url)
   end
 end

--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -30,6 +30,17 @@ module ExternalLinkHelper
     end
   end
 
+  def link_to_linkedin(user, &block)
+    return unless user.linkedin
+    url = "http://www.linkedin.com/in/#{user.github}"
+    title = user.linkedin
+    if block_given?
+      link_to url, title: title, &block
+    else
+      link_to(user.linkedin, url, title: title)
+    end
+  end
+
   def mailing_list_url
     group = Whitelabel[:google_group] || 'rubyonrails-ug-germany'
     "https://groups.google.com/group/#{group}"

--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -32,7 +32,7 @@ module ExternalLinkHelper
 
   def link_to_linkedin(user, &block)
     return unless user.linkedin
-    url = "http://www.linkedin.com/in/#{user.github}"
+    url = "http://www.linkedin.com/in/#{user.linkedin}"
     title = user.linkedin
     if block_given?
       link_to url, title: title, &block

--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -2,7 +2,7 @@ module ExternalLinkHelper
   def wheelmap_badge(location, klass: 'wheelmap-status')
     return unless location.wheelmap_id.present?
 
-    url   =  "http://wheelmap.org/nodes/#{location.wheelmap_id}"
+    url   =  "https://wheelmap.org/nodes/#{location.wheelmap_id}"
     image = image_tag "https://img.shields.io/wheelmap/a/#{location.wheelmap_id}.svg", class: klass
 
     link_to image, url
@@ -10,7 +10,7 @@ module ExternalLinkHelper
 
   def link_to_twitter(thing, params = { clung: false }, &block)
     nick = thing.respond_to?(:twitter) ? thing.twitter : thing
-    url = "http://twitter.com/#{nick}"
+    url = "https://twitter.com/#{nick}"
     if block_given?
       link_to url, title: nick, &block
     else
@@ -21,7 +21,7 @@ module ExternalLinkHelper
 
   def link_to_github(user, &block)
     return unless user.github
-    url = "http://github.com/#{user.github}"
+    url = "https://github.com/#{user.github}"
     title = user.github
     if block_given?
       link_to url, title: title, &block
@@ -32,7 +32,7 @@ module ExternalLinkHelper
 
   def link_to_linkedin(user, &block)
     return unless user.linkedin
-    url = "http://www.linkedin.com/in/#{user.linkedin}"
+    url = "https://www.linkedin.com/in/#{user.linkedin}"
     title = user.linkedin
     if block_given?
       link_to url, title: title, &block
@@ -86,7 +86,7 @@ module ExternalLinkHelper
       options = { username: model.user.name, name: model.name.truncate(50), url: topic_url(model) }
     end
     text = t("#{model.class.to_s.downcase}.twitter_message", options)
-    "http://twitter.com/home?status=#{URI.encode(text)}"
+    "https://twitter.com/home?status=#{URI.encode(text)}"
   end
 
   def likes
@@ -107,8 +107,8 @@ module ExternalLinkHelper
   def ribbon(type)
     types = {
       github:                 ['Fork me on GitHub!',  'https://github.com/phoet/on_ruby'],
-      senor_developer:        ['Señor Developer!',    'http://senordevelopershop.spreadshirt.de'],
-      rgsoc:                  ['SUMMER OF CODE',      'http://railsgirlssummerofcode.org/campaign/'],
+      senor_developer:        ['Señor Developer!',    'https://senordevelopershop.spreadshirt.de'],
+      rgsoc:                  ['SUMMER OF CODE',      'https://railsgirlssummerofcode.org/campaign/'],
     }
     text, url = types[type]
     content_tag :div, id: "#{type}_ribbon", class: 'ribbon_wrap' do

--- a/app/views/users/edit.slim
+++ b/app/views/users/edit.slim
@@ -8,6 +8,7 @@ section
         = f.input :twitter, input_html: { placeholder: 'Twitter handle' }
     - unless user.with_provider? :github
         = f.input :github, input_html: { placeholder: 'GitHub handle' }
+    = f.input :linkedin, input_html: { placeholder: 'Linkedin handle' }
     = f.input :email
     = f.input :url
     = f.input :description, type: :text_area

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -15,6 +15,10 @@ section
         span
           = fa_icon 'github', class: 'pull-left'
           = link_to_github user
+      - if user.linkedin?
+        span
+            = fa_icon 'linkedin', class: 'bg-danger pull-left'
+            = link_to_linkedin user
       - if user.url?
         span
           = fa_icon 'bookmark', class: 'pull-left'

--- a/db/migrate/20180913110659_add_linkedin_to_users.rb
+++ b/db/migrate/20180913110659_add_linkedin_to_users.rb
@@ -1,0 +1,8 @@
+class AddLinkedinToUsers < ActiveRecord::Migration[5.0]
+  def up
+    add_column :users, :linkedin, :string
+  end
+  def down
+    remove_column :users, :linkedin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170918091427) do
+ActiveRecord::Schema.define(version: 20180913110659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,9 +21,8 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["user_id"], name: "index_authorizations_on_user_id", using: :btree
   end
-
-  add_index "authorizations", ["user_id"], name: "index_authorizations_on_user_id", using: :btree
 
   create_table "events", force: :cascade do |t|
     t.string   "name"
@@ -37,10 +35,9 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.boolean  "published"
     t.string   "label",       default: "hamburg"
     t.integer  "limit"
+    t.index ["location_id"], name: "index_events_on_location_id", using: :btree
+    t.index ["user_id"], name: "index_events_on_user_id", using: :btree
   end
-
-  add_index "events", ["location_id"], name: "index_events_on_location_id", using: :btree
-  add_index "events", ["user_id"], name: "index_events_on_user_id", using: :btree
 
   create_table "highlights", force: :cascade do |t|
     t.string   "description"
@@ -59,9 +56,8 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.string   "label",       default: "hamburg"
+    t.index ["location_id"], name: "index_jobs_on_location_id", using: :btree
   end
-
-  add_index "jobs", ["location_id"], name: "index_jobs_on_location_id", using: :btree
 
   create_table "likes", force: :cascade do |t|
     t.integer  "user_id"
@@ -84,9 +80,8 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.boolean  "company"
     t.string   "label",        default: "hamburg"
     t.string   "wheelmap_id"
+    t.index ["id"], name: "index_locations_on_id", using: :btree
   end
-
-  add_index "locations", ["id"], name: "index_locations_on_id", using: :btree
 
   create_table "materials", force: :cascade do |t|
     t.string   "name"
@@ -99,10 +94,9 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.string   "preview_type"
     t.string   "preview_code"
     t.integer  "topic_id"
+    t.index ["event_id"], name: "index_materials_on_event_id", using: :btree
+    t.index ["user_id"], name: "index_materials_on_user_id", using: :btree
   end
-
-  add_index "materials", ["event_id"], name: "index_materials_on_event_id", using: :btree
-  add_index "materials", ["user_id"], name: "index_materials_on_user_id", using: :btree
 
   create_table "participants", force: :cascade do |t|
     t.integer  "user_id"
@@ -111,10 +105,9 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.text     "comment"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["event_id"], name: "index_participants_on_event_id", using: :btree
+    t.index ["user_id"], name: "index_participants_on_user_id", using: :btree
   end
-
-  add_index "participants", ["event_id"], name: "index_participants_on_event_id", using: :btree
-  add_index "participants", ["user_id"], name: "index_participants_on_user_id", using: :btree
 
   create_table "topics", force: :cascade do |t|
     t.string   "name"
@@ -125,10 +118,9 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.datetime "updated_at"
     t.string   "label",         default: "hamburg"
     t.string   "proposal_type", default: "proposal"
+    t.index ["event_id"], name: "index_topics_on_event_id", using: :btree
+    t.index ["user_id"], name: "index_topics_on_user_id", using: :btree
   end
-
-  add_index "topics", ["event_id"], name: "index_topics_on_event_id", using: :btree
-  add_index "topics", ["user_id"], name: "index_topics_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "nickname"
@@ -147,8 +139,8 @@ ActiveRecord::Schema.define(version: 20170918091427) do
     t.string   "twitter"
     t.string   "email"
     t.boolean  "super_admin", default: false
+    t.string   "linkedin"
+    t.index ["nickname"], name: "index_users_on_nickname", unique: true, using: :btree
   end
-
-  add_index "users", ["nickname"], name: "index_users_on_nickname", unique: true, using: :btree
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ describe UsersController do
   let(:user) { create(:user) }
   let(:user_with_events) { create(:organizer_user) }
   let(:user_with_participations) { create(:participant_user) }
-  let(:data) { { id: user.to_param, user: { github: 'testo', freelancer: true, available: true } } }
+  let(:data) { { id: user.to_param, user: { github: 'testo', linkedin: 'testyin', freelancer: true, available: true } } }
   let(:unallowed_data) { data.merge(user: { nickname: 'not_allowed_property' }) }
 
   context 'GET :show' do
@@ -82,6 +82,7 @@ describe UsersController do
       expect(response).to be_a_redirect
 
       expect(user.github).to eql('testo')
+      expect(user.linkedin).to eql('testyin')
       expect(user.freelancer).to be_truthy
       expect(user.available).to be_truthy
     end

--- a/spec/helpers/external_link_helper_spec.rb
+++ b/spec/helpers/external_link_helper_spec.rb
@@ -20,6 +20,23 @@ describe ExternalLinkHelper do
     end
   end
 
+  context '#link_to_linkedin' do
+    it 'should generate the link' do
+      user = build(:user, linkedin: 'testyin')
+      expect(helper.link_to_linkedin(user)).to eql('<a title="testyin" href="http://www.linkedin.com/in/testyin">testyin</a>')
+    end
+
+    it 'should generate the link with a block' do
+      user = build(:user, linkedin: 'testyin')
+      expect(helper.link_to_linkedin(user) { 'testyin' }).to eql('<a title="testyin" href="http://www.linkedin.com/in/testyin">testyin</a>')
+    end
+
+    it 'should render nothing for no linkedin' do
+      user.linkedin = nil
+      expect(helper.link_to_linkedin(user)).to be_nil
+    end
+  end
+
   context '#mailing_list_entries' do
     it 'fetches and parses a feed' do
       expect(mailing_list_entries).to have(15).items

--- a/spec/helpers/external_link_helper_spec.rb
+++ b/spec/helpers/external_link_helper_spec.rb
@@ -6,12 +6,12 @@ describe ExternalLinkHelper do
   context '#link_to_github' do
     it 'should generate the link' do
       user = build(:user, github: 'giddiup')
-      expect(helper.link_to_github(user)).to eql('<a title="giddiup" href="http://github.com/giddiup">giddiup</a>')
+      expect(helper.link_to_github(user)).to eql('<a title="giddiup" href="https://github.com/giddiup">giddiup</a>')
     end
 
     it 'should generate the link with a block' do
       user = build(:user, github: 'giddiup')
-      expect(helper.link_to_github(user) { 'uschi' }).to eql('<a title="giddiup" href="http://github.com/giddiup">uschi</a>')
+      expect(helper.link_to_github(user) { 'uschi' }).to eql('<a title="giddiup" href="https://github.com/giddiup">uschi</a>')
     end
 
     it 'should render nothing for no github' do
@@ -23,12 +23,12 @@ describe ExternalLinkHelper do
   context '#link_to_linkedin' do
     it 'should generate the link' do
       user = build(:user, linkedin: 'testyin')
-      expect(helper.link_to_linkedin(user)).to eql('<a title="testyin" href="http://www.linkedin.com/in/testyin">testyin</a>')
+      expect(helper.link_to_linkedin(user)).to eql('<a title="testyin" href="https://www.linkedin.com/in/testyin">testyin</a>')
     end
 
     it 'should generate the link with a block' do
       user = build(:user, linkedin: 'testyin')
-      expect(helper.link_to_linkedin(user) { 'testyin' }).to eql('<a title="testyin" href="http://www.linkedin.com/in/testyin">testyin</a>')
+      expect(helper.link_to_linkedin(user) { 'testyin' }).to eql('<a title="testyin" href="https://www.linkedin.com/in/testyin">testyin</a>')
     end
 
     it 'should render nothing for no linkedin' do
@@ -55,7 +55,7 @@ describe ExternalLinkHelper do
   context '#link_to_twitter' do
     it 'should generate the link' do
       user = build(:user, twitter: 'klaus')
-      expect(helper.link_to_twitter(user)).to eql('@<a title="klaus" href="http://twitter.com/klaus">klaus</a>')
+      expect(helper.link_to_twitter(user)).to eql('@<a title="klaus" href="https://twitter.com/klaus">klaus</a>')
     end
   end
 
@@ -67,13 +67,13 @@ describe ExternalLinkHelper do
       topic.user.name = 'Uschi'
 
       url = helper.twitter_update_url(topic)
-      expect(url).to match(Regexp.escape('http://twitter.com/home?status=Neues%20Thema%20von%20@Uschi'))
+      expect(url).to match(Regexp.escape('https://twitter.com/home?status=Neues%20Thema%20von%20@Uschi'))
       expect(url).to match(Regexp.escape('http://test.host/topics/bla-999'))
     end
 
     it 'should generate a proper url for events' do
       url = helper.twitter_update_url(event)
-      expect(url).to match(Regexp.escape('http://twitter.com/home?status=Weihnachtstreffen'))
+      expect(url).to match(Regexp.escape('https://twitter.com/home?status=Weihnachtstreffen'))
       expect(url).to match(Regexp.escape('am%2006.%20Dezember,%2011:47%20Uhr'))
       expect(url).to match(Regexp.escape('http://test.host/events/weihnachtstreffen'))
     end


### PR DESCRIPTION
Development to update and close the #435 new feature.
The user profile can now optionally have a linkedin field.
Tests have been added in the following spec sections.
spec/controllers/users_controller_spec.rb:75
spec/helpers/external_link_helper_spec.rb:25
script/in_docker bundle exec rspec ./spec/controllers/users_controller_spec.rb:75
script/in_docker bundle exec rspec ./spec/helpers/external_link_helper_spec.rb:25
(run script/in_docker bundle exec rake db:test:prepare before running, as their is a new migration for user_profile linkedin). 
Deployment will need a rake db:migration 
Work by @alterisian and @Adsidera after surveying the RUG B mailing list indicated a need for this feature from a significant proportion of respondents. 