### PR TITLE
iOS push notifications removed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'feedjira'
 gem 'formtastic'
 gem 'kaminari'
 gem 'typus', git: 'https://github.com/typus/typus.git', branch: '5-0-unstable'
-gem 'one_signal'
 gem 'link_thumbnailer'
 gem 'validate_url'
 # assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,6 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    one_signal (1.2.0)
     partially_useful (5.1.0)
       railties (>= 4.1)
     pg (1.1.3)
@@ -383,7 +382,6 @@ DEPENDENCIES
   omniauth
   omniauth-github
   omniauth-twitter
-  one_signal
   partially_useful
   pg (= 1.1.3)
   puma

--- a/app.json
+++ b/app.json
@@ -94,12 +94,6 @@
     "OMNIAUTH_GITHUB_RUGB_DE_SECRET": {
       "required": true
     },
-    "ONE_SIGNAL_APP_ID": {
-      "required": true
-    },
-    "ONE_SIGNAL_KEY": {
-      "required": true
-    },
     "PATH": {
       "required": true
     },

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -11,27 +11,4 @@ class Admin::EventsController < Admin::ApplicationController
 
     redirect_to url_for(controller: '/admin/events', action: :edit, id: event.id), notice: 'Published!'
   end
-
-  def send_ios_push_notification
-    event = Event.find_by_slug(params[:id])
-
-    options = {
-      app_id: ENV['ONE_SIGNAL_APP_ID'],
-      included_segments: [Whitelabel[:label_id]],
-      contents: {
-        en: "#{I18n.tw('name')}: new event at #{I18n.l(event.date)}"
-      },
-      content_available: true
-    }
-
-    notification_call = OneSignal::Notification.create(params: options)
-
-    if notification_call.code == '200'
-      message = { notice: 'iOS Push Notification sent!' }
-    else
-      message = { alert: 'iOS Push Notification could not be sent!' }
-    end
-
-    redirect_to url_for(controller: '/admin/events', action: :show, id: event.id), message
-  end
 end

--- a/app/views/admin/dashboard/_sidebar.slim
+++ b/app/views/admin/dashboard/_sidebar.slim
@@ -7,8 +7,6 @@ h3 Event Actions
       li
         = "#{event.name}: "
         = link_to("tweet", twitter_update_url(event))
-        = " / "
-        = button_to("send ios push notification", url_for(controller: "/admin/events", action: :send_ios_push_notification, id: event.id), method: :post)
 
 p= button_to 'Duplicate latest Event', '/admin/events/duplicate', method: :post
 

--- a/config/initializers/zero_push.rb
+++ b/config/initializers/zero_push.rb
@@ -1,1 +1,0 @@
-OneSignal::OneSignal.api_key = ENV['ONE_SIGNAL_KEY']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,6 @@ OnRuby::Application.routes.draw do
     post '/topics/add_to_next_event', to: 'topics#add_to_next_event'
     post '/events/duplicate', to: 'events#duplicate'
     post '/events/publish', to: 'events#publish'
-    post '/events/send_ios_push_notification', to: 'events#send_ios_push_notification'
   end
 
   scope '/auth' do

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -35,24 +35,5 @@ describe Admin::EventsController do
         }.by(1)
       end
     end
-
-    context 'GET :send_ios_push_notification' do
-      it 'send notification with zeropush' do
-        event = create(:event)
-
-        expect(OneSignal::Notification).to receive(:create).with(
-          params: {
-            app_id: nil,
-            included_segments: [Whitelabel[:label_id]],
-            contents: {
-              en: "#{I18n.tw('name')}: new event at #{I18n.l(event.date)}"
-            },
-            content_available: true
-          }
-        ).and_return(OpenStruct.new(code: '200'))
-
-        get :send_ios_push_notification, params: { id: event.id }
-      end
-    end
   end
 end


### PR DESCRIPTION
* [ ] remove one_signal environment variables ONE_SIGNAL_APP_ID and ONE_SIGNAL_KEY from Heroku

This PR removes the ability to send iOS Push Notifications. The iOS app is no longer available in the store.