### PR TITLE
Fix cocoaheads twitter handle

### DIFF
--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -30,7 +30,7 @@
     :twitter: hhjs
   - :name: Cocoaheads
     :url: https://www.meetup.com/de-DE/CocoaHeads-Hamburg/
-    :twitter: hh_cocoaheads
+    :twitter: cocoaheads_hh
   tld: de
   coc: http://rubyberlin.github.io/code-of-conduct
 - !ruby/object:Usergroup


### PR DESCRIPTION
Thx to @lukad for noticing.

See https://twitter.com/cocoaheads_hh

Rughh on premise hotfixes ftw.

