### PR TITLE
Update factories to keyword arguments

### DIFF
--- a/spec/support/factories/events.rb
+++ b/spec/support/factories/events.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :event do
-    name        { Faker::Lorem.words(6).join }
+    name        { Faker::Lorem.words(number: 6).join }
     date        { rand(3).days.from_now }
-    description { Faker::Lorem.sentences(3).join }
+    description { Faker::Lorem.sentences(number: 3).join }
     association :location, strategy: :build
     association :user, strategy: :build
     created_at  { Time.now }

--- a/spec/support/factories/highlights.rb
+++ b/spec/support/factories/highlights.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :highlight do
-    description { Faker::Lorem.words(6).join }
+    description { Faker::Lorem.words(number: 6).join }
     url         { Faker::Internet.url }
     start_at    { Date.tomorrow }
     end_at      { rand(5).days.from_now }

--- a/spec/support/factories/materials.rb
+++ b/spec/support/factories/materials.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     event
     user
     topic
-    name { Faker::Lorem.words(5).join }
+    name { Faker::Lorem.words(number: 5).join }
     url { Faker::Internet.url }
   end
 end

--- a/spec/support/factories/topics.rb
+++ b/spec/support/factories/topics.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :proposal, class: :topic do
     user
-    name            { Faker::Lorem.words(5).join }
-    description     { Faker::Lorem.sentences(3).join }
+    name            { Faker::Lorem.words(number: 5).join }
+    description     { Faker::Lorem.sentences(number: 3).join }
     proposal_type   { 'proposal' }
   end
 


### PR DESCRIPTION
To avoid deprecation warnings when running `rake data:create` like this one:

_Passing `number` with the 1st argument of `words` is deprecated. Use keyword argument like `words(number: ...)` instead._