### PR TITLE
Allow all .onruby.test domains in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,10 +1,6 @@
+# Settings specified here will take precedence over those in config/application.rb.
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-  config.hosts << "hamburg.onruby.test"
-  config.hosts << "berlin.onruby.test"
-  config.hosts << "cologne.onruby.test"
-  config.hosts << "www.onruby.test"
-  config.hosts << "madridrb.onruby.test"
+  config.hosts << /.*onruby\.test.*/
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development


### PR DESCRIPTION
Rails 6 introduced this check:
https://www.fngtps.com/2019/rails6-blocked-host/