### PR TITLE
Fix rake fork by adding canonical_url to Usergroup.from_name

### DIFF
--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -85,6 +85,7 @@ class Usergroup
       it.label_id = it.google_group = it.twitter = name.underscore
       it.default_locale   = 'de'
       it.tld              = 'de'
+      it.canonical_url    = "https://#{name.parameterize}.onruby.de"
       it.country          = 'Deutschland'
       it.domains          = ["#{name.parameterize}.de"]
       it.recurring        = 'second wednesday'


### PR DESCRIPTION
That was missing to enable a smooth experience setting up a new user group