### PR TITLE
Sort administrate menu

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,14 +4,14 @@ OnRuby::Application.routes.draw do
       post :duplicate, on: :collection
       post :connect, on: :member
     end
-    resources :authorizations
+    resources :locations
+    resources :topics
+    resources :materials
     resources :highlights
     resources :jobs
+    resources :authorizations
     resources :likes
-    resources :locations
-    resources :materials
     resources :participants
-    resources :topics
     resources :users
 
     root to: "events#index"


### PR DESCRIPTION
Ok, I would understand if someone that used the onruby/admin for years already would oppose this change. 😉 

But after using the admin section for half day, I am convinced the items I will use most often are:

* events
* locations
* topics

therefore I added those three on top. Followed by:

* materials (as this directly interacts with topics)
* highlights
* jobs

And the last items are the 4 global ones, that deal with users and their interactions:

* authorizations
* likes
* participants
* users

While this change might be seen controversial, I am convinced it is an improvement. 