### PR TITLE
Display jobs also when a highlight is active

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -33,11 +33,11 @@ module LinkHelper
   end
 
   def job_description(job)
-    t('hint.job_description', city: I18n.tw('city'), job_link: content_tag(:strong, link_to(job.name, job.url, title: job.name)), company_link: link_to_location(job.location))
+    t('hint.job_description', city: I18n.tw('city'), job_link: content_tag(:strong, link_to(job.name, job.url, title: job.name, target: '_blank')), company_link: link_to_location(job.location))
   end
 
   def link_to_location(location)
-    "#{link_to location.name, location, title: location.name} (#{link_to location.nice_url, location.url, title: location.name})".html_safe
+    "#{link_to location.name, location, title: location.name} (#{link_to location.nice_url, location.url, title: location.name, target: '_blank'})".html_safe
   end
 
   def link_to_route(location)

--- a/app/views/application/_hint.slim
+++ b/app/views/application/_hint.slim
@@ -9,14 +9,15 @@
         - highlights.each do |highlight|
           .highlights
             strong=> t("hint.attention")
-            = link_to highlight.description, highlight.url, title: highlight.description
-  - elsif jobs.present?
+            = link_to highlight.description, highlight.url, title: highlight.description, target:  "_blank"
+  - if jobs.present?
     - unless current_user && current_user.hide_jobs?
       = hint(false) do
         #job-teaser
           ul
             li
-              span.job-toggle= link_to fa_icon("chevron-down"), '#', title: t("hint.click_to_refresh")
+              - if jobs.count > 1
+                span.job-toggle= link_to fa_icon("chevron-down"), '#', title: t("hint.click_to_refresh")
               .job.ml-4== job_description(jobs.first)
         #job-list.hidden
           ul


### PR DESCRIPTION
At the moment jobs are not displayed at the top of the page, when a highlight is active. I don't know if this was a design decision at some point, but I'd argue we should always display the (few) jobs we have on the page.

When there is only one job offer, the chevron is not displayed anymore.

This change also opens linked pages of highlights, jobs descriptions and locations in a new tab.