### PR TITLE
Fix mobile view of Barcelona's topics

### DIFF
--- a/app/assets/stylesheets/labels/barcelona.sass
+++ b/app/assets/stylesheets/labels/barcelona.sass
@@ -1,2 +1,7 @@
+@import "application"
+
 .topic-card-columns
-  column-count: 2
+  @include media-breakpoint-down(md)
+    column-count: 1
+  @include media-breakpoint-up(lg)
+    column-count: 2


### PR DESCRIPTION
The last PR went not fast enough, as it ignored how bootstrap's responsiveness works on smaller screens.

The new behavior (for event's topics of Barcelona only) is now, that on big screens always two topics will be displayed besides each other, while on smaller screens (like mobile phones) each topic gets the full width available. The breakpoint from 1 to 2 columns is deliberately late at around 1000px screen-width, as the topic box can only use around half of that in the current design. 
