### PR TITLE
Fix events talk list indention & add word-break to section lists

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -237,8 +237,15 @@ header
       margin-bottom: 0.75em
 
     #undone, #done, #upcoming, #events, #current_undone
+      .more-list
+        word-break: break-all
       li
         margin: 0em 0em 1em 0em
+
+    #events
+      .more-list
+        li:last-of-type
+          padding-bottom: 1.5em
 
   .user
     .image

--- a/app/views/events/index.slim
+++ b/app/views/events/index.slim
@@ -4,8 +4,8 @@
       strong= link_to_event event
       = " (#{l(event.date, format: :date)})"
     ul.more-list.undone.clearfix
-    - event.topics.each do |topic|
-      li.topic= link_to_topic topic
+      - event.topics.each do |topic|
+        li.topic= link_to_topic topic
   = paginate events
 
   p.meta


### PR DESCRIPTION
When browsing our RUG::B talk archive, something seemed a bit off with the way talks were displayed underneath events. Looks like it was a SLIM indention error.

When checking for how my "fix" looked mobile, I came across another issue with very long talk titles (unlikely to happen IRL) and tried to provide a fix for this by adding a `word-break` rule.

Please see attached screenshots for details and let me know what you think!


**Event page before changes**
![onruby_events_old](https://user-images.githubusercontent.com/16822008/83678665-63912200-a5de-11ea-9352-d283b1a9e305.png)
**Event page after changes**
![onruby_events_new](https://user-images.githubusercontent.com/16822008/83678661-612ec800-a5de-11ea-9368-d698253c6d24.png)


**Mobile home page before changes**
![onruby_home_events_old](https://user-images.githubusercontent.com/16822008/83678673-64c24f00-a5de-11ea-95c1-279f27fb09fd.png)
**Mobile home page after changes**
![onruby_home_events_new](https://user-images.githubusercontent.com/16822008/83678670-64c24f00-a5de-11ea-98d5-dfbd8ff4a5a3.png)

