### PR TITLE
Madrid.rb new organizer

### DIFF
--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -376,8 +376,8 @@
       Av del Brasil, 7 (The Irish Rover)
       28020 Madrid, Spain 1
     :contributors:
-    - :name: Enrique García Cota
-      :email: kikito@gmail.com
+    - :name: Josep Egea Sánchez
+      :email: hello@madridrb.com
   sponsors:
   - :name: Bebanjo
     :url: http://bebanjo.com/

--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -365,7 +365,7 @@
   email: hello@madridrb.com
   twitter: madridrb
   organizers:
-  - otikik
+  - josep_egea
   location:
     :zoom: 12
     :lat: 40.42


### PR DESCRIPTION
Hello, Madrid.rb has a new organizer.

His name is **Josep Egea Sánchez**. He already has an account in onruby.

* on_ruby nickname: josep_egea
* on_ruby id: /admin/users/josep_egea-1406

In addition of merging this PR, I would like to request the following
changes:

* That Josep's user account is promoted to administrator of the
  Madrid.rb group
* That Josep's Github account (@josepegea) is given the same access to
  the on_ruby github repository that I (kikito) currently possess.
* That my accounts (on_ruby: kikito-1369 / github: kikito)
  are downgraded to match.

There's proof that this request is legitimate (and my account has not
been hacked) in the Madrid.rb mailing list, where I make the
announcement (it is in Spanish, but a Google translate should do):

https://groups.google.com/g/madrid-rb/c/2Uo0fwHKfE0

I will also provide a written approval for this from my personal email,
which I have used in the past to talk with @phoet while setting up the
group in the website.

I am very happy with this arrangement and I am very grateful to Josep
for stepping up after my call for a replacement. I am also very grateful
to the Ruby community at large and to Phoet for creating the community
website, which has helped so many people.

Regards!