### PR TITLE
Add virtual locations and remote links for events

### DIFF
--- a/app/dashboards/event_dashboard.rb
+++ b/app/dashboards/event_dashboard.rb
@@ -25,6 +25,7 @@ class EventDashboard < Administrate::BaseDashboard
     published: Field::Boolean,
     label: Field::String,
     limit: Field::Number,
+    remote_url: Field::String,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -53,6 +54,7 @@ class EventDashboard < Administrate::BaseDashboard
     :date,
     :description,
     :attendee_information,
+    :remote_url,
     :created_at,
     :updated_at,
     :published,
@@ -69,6 +71,7 @@ class EventDashboard < Administrate::BaseDashboard
     :name,
     :description,
     :attendee_information,
+    :remote_url,
     :user,
     :location,
     :limit,

--- a/app/dashboards/location_dashboard.rb
+++ b/app/dashboards/location_dashboard.rb
@@ -22,6 +22,7 @@ class LocationDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     company: Field::Boolean,
+    virtual: Field::Boolean,
     label: Field::String,
     wheelmap_id: Field::String,
   }.freeze
@@ -42,6 +43,7 @@ class LocationDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
     :company,
+    :virtual,
     :events,
     :jobs,
     :id,
@@ -64,6 +66,7 @@ class LocationDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = [
     :name,
     :company,
+    :virtual,
     :url,
     :street,
     :house_number,

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -29,6 +29,7 @@ module EventsHelper
 
   def remote_url_link(event, link_class: 'btn btn-primary')
     return unless signed_in? && current_user.participates?(event) && event.remote_url.present?
+
     link_to t('events.connect_remotely'), event.remote_url, class: link_class
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -26,4 +26,9 @@ module EventsHelper
   def events_im_attending_link
     fa_icon('calendar', text: link_to(t('events.webcal'), calendar_user_url(id: current_user, format: :ics, protocol: 'webcal')))
   end
+
+  def remote_url_link(event, link_class: 'btn btn-primary')
+    return unless signed_in? && current_user.participates?(event) && event.remote_url.present?
+    link_to t('events.connect_remotely'), event.remote_url, class: link_class
+  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,15 +3,16 @@
 class Location < ApplicationRecord
   include Slug
   extend ApiHandling
-  expose_api :id, :name, :url, :city, :street, :house_number, :zip, :wheelmap_id
+  expose_api :id, :name, :url, :virtual, :city, :street, :house_number, :zip, :wheelmap_id
 
   geocoded_by :geo_coder_address, latitude: :lat, longitude: :long
-  after_validation :geocode
+  after_validation :geocode, unless: :virtual?
 
   has_many :events
   has_many :jobs
 
-  validates :name, :url, :city, :street, :house_number, :zip, presence: true
+  validates :name, :url, presence: true
+  validates :city, :street, :house_number, :zip, presence: true, unless: :virtual?
   validates :url, length: { maximum: 255 }
 
   scope :ordered, -> { order('name ASC') }

--- a/app/views/events/_badges.slim
+++ b/app/views/events/_badges.slim
@@ -1,6 +1,6 @@
 span.badge.badge-card-header.mr-2
   = fa_icon('calendar', text: link_to(l(event.date, format: :long), event_path(event, format: :ics)))
-- if event.location.present?
+- if event.location.present? && !event.location.virtual?
   span.badge.badge-card-header.mr-2
     = fa_icon('map-marker', text: link_to(event.location.address, '#route', title: event.location.address))
   span.badge.badge-card-header.mr-2

--- a/app/views/events/_info.slim
+++ b/app/views/events/_info.slim
@@ -11,6 +11,7 @@
 
   .col-lg-3
     = participation_link(event, link_class: 'btn btn-primary btn-block')
+    = remote_url_link(event, link_class: 'btn btn-primary btn-block')
 
 .card-text
   == markdown(event.description)

--- a/app/views/events/_location.slim
+++ b/app/views/events/_location.slim
@@ -1,4 +1,4 @@
-- if event.location.present?
+- if event.location.present? && !event.location.virtual?
     h3.card-title
       = t("show.route")
       - if event.location.wheelmap_id?

--- a/app/views/locations/show.slim
+++ b/app/views/locations/show.slim
@@ -1,23 +1,29 @@
 .card
   .card-header
-    span.badge.badge-card-header.mr-2
-      = fa_icon('map-marker', text: link_to(location.address, '#route', title: location.address))
+    - unless location.virtual?
+      span.badge.badge-card-header.mr-2
+        = fa_icon('map-marker', text: link_to(location.address, '#route', title: location.address))
     span.badge.badge-card-header.mr-2
       = fa_icon('bookmark', text: link_to(location.nice_url, location.url, title: location.name))
-    span.badge.badge-card-header.mr-2
-      = fa_icon('external-link', text: link_to_external_route(location))
+    - if location.virtual?
+      small.text-muted
+        = t("location.virtual_location")
+    - else
+      span.badge.badge-card-header.mr-2
+        = fa_icon('external-link', text: link_to_external_route(location))
 
   .card-body
     h2.card-title
       = location.name
 
-    h3
-      = t("show.route")
-      - if location.wheelmap_id?
-        .pull-right
-          = wheelmap_badge location
+    - unless location.virtual?
+      h3
+        = t("show.route")
+        - if location.wheelmap_id?
+          .pull-right
+            = wheelmap_badge location
 
-    #route= single_map(location)
+      #route= single_map(location)
 
     - if location.jobs.present?
       h3.card-title= t("location.job_offers")

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -105,6 +105,7 @@ de:
     job_offers: "Jobangebote"
     open_in: "Öffnen in"
     google_maps: "Google Maps"
+    virtual_location: "Virtueller Ort"
   topic:
     topic: "Thema"
     all_topics: "Alle Themen"
@@ -137,6 +138,7 @@ de:
     im_attending_html: "Meine Events abonieren: %{events_im_attending_link}"
     webcal: 'Webcal'
     rss: 'RSS'
+    connect_remotely: 'Remote-Verbindung'
     coc:
       html: 'Die Events unserer Usergroup unterstützten folgenden <a href="%{coc_link}" target="_blank">Code of Conduct</a>.'
   flash:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,7 @@ en:
     job_offers: "Job offers"
     open_in: "Open in"
     google_maps: "Google Maps"
+    virtual_location: "Virtual Location"
   topic:
     topic: "Topic"
     all_topics: "All Topics"
@@ -137,6 +138,7 @@ en:
     im_attending_html: "Events I'm attending: %{events_im_attending_link}"
     webcal: 'Webcal'
     rss: 'RSS'
+    connect_remotely: 'Connect Remotely'
     coc:
       html: 'The Events of this Usergroup support this <a href="%{coc_link}" target="_blank">Code of Conduct</a>.'
   flash:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -106,6 +106,7 @@ es:
     job_offers: "Ofertas de empleo"
     open_in: "Abrir con"
     google_maps: "Google Maps"
+    virtual_location: "Sede Virtual"
   topic:
     topic: "Tema"
     all_topics: "Todos los temas"
@@ -138,6 +139,7 @@ es:
     im_attending_html: "Eventos a los que me apunté: %{events_im_attending_link}"
     webcal: 'Webcal'
     rss: 'RSS'
+    connect_remotely: 'Conectar en Remoto'
     coc:
       html: 'Eventos utilizar se <a href="%{coc_link}" target="_blank">Code of Conduct</a>.'
   flash:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -105,6 +105,7 @@ pl:
     job_offers: "Oferty pracy"
     open_in: "Otwiera się za"
     google_maps: "Google Maps"
+    virtual_location: "Wirtualna Lokacja"
   topic:
     topic: "temat"
     all_topics: "Wszystkie tematy"
@@ -137,6 +138,7 @@ pl:
     im_attending_html: "Wydarzenia w których biorę udział: %{events_im_attending_link}"
     webcal: 'Webcal'
     rss: 'RSS'
+    connect_remotely: 'Połącz zdalnie'
     coc:
       html: 'Spotkania w tej Grupie honoruję ten <a href="%{coc_link}" target="_blank">Code of Conduct</a>.'
   flash:

--- a/db/migrate/20210113033955_add_virtual_locations.rb
+++ b/db/migrate/20210113033955_add_virtual_locations.rb
@@ -1,0 +1,6 @@
+class AddVirtualLocations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :locations, :virtual, :boolean, default: false
+    add_column :events, :remote_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_29_213652) do
+ActiveRecord::Schema.define(version: 2021_01_13_033955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_213652) do
     t.integer "limit"
     t.integer "github_issue"
     t.text "attendee_information"
+    t.string "remote_url"
     t.index ["location_id"], name: "index_events_on_location_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
@@ -82,6 +83,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_213652) do
     t.boolean "company"
     t.string "label", default: "hamburg"
     t.string "wheelmap_id"
+    t.boolean "virtual", default: false
     t.index ["id"], name: "index_locations_on_id"
   end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -105,6 +105,7 @@ describe EventsController do
             'house_number' => event.location.house_number,
             'zip' => event.location.zip,
             'wheelmap_id' => event.location.wheelmap_id,
+            'virtual' => event.location.virtual,
           }
         )
       end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 describe Location do
   before(:each) do
-    @location       = create(:location, name: 'Test-Location', street: 'Schanzenstr.', house_number: '85', zip: '20357', city: 'Hamburg')
-    @other_location = create(:location, label: 'cologne')
-    @es_location    = create(:location, label: 'madridrb')
+    @location         = create(:location, name: 'Test-Location', street: 'Schanzenstr.', house_number: '85', zip: '20357', city: 'Hamburg')
+    @other_location   = create(:location, label: 'cologne')
+    @es_location      = create(:location, label: 'madridrb')
+    @virtual_location = create(:virtual_location, label: 'madridrb')
   end
 
   context 'validation' do
@@ -17,6 +18,10 @@ describe Location do
     it 'validates length of url' do
       expect(build(:location, url: very_long_url)).to have(1).errors_on(:url)
     end
+
+    it 'accepts virtual locations without geo info' do
+      expect(build(:virtual_location)).to be_valid
+    end
   end
 
   context 'finder' do
@@ -24,7 +29,7 @@ describe Location do
       hamburg_locations = Location.all
       expect(hamburg_locations).to have(1).elements
       expect(hamburg_locations.first).to eql(@location)
-      expect(Location.unscoped.size).to be(3)
+      expect(Location.unscoped.size).to be(4)
     end
   end
 
@@ -44,6 +49,11 @@ describe Location do
         expect(locn.lat).to_not be_nil
         expect(locn.long).to_not be_nil
       end
+    end
+
+    it 'should not geocode virtual locations' do
+      expect(@virtual_location.lat).to be_nil
+      expect(@virtual_location.long).to be_nil
     end
 
     it 'should geocode with expected data once a location is saved' do

--- a/spec/support/factories/events.rb
+++ b/spec/support/factories/events.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     date        { rand(3).days.from_now }
     description { Faker::Lorem.sentences(number: 3).join }
     attendee_information { Faker::Lorem.sentences(number: 3).join }
+    remote_url { Faker::Internet.url }
     association :location, strategy: :build
     association :user, strategy: :build
     created_at  { Time.now }

--- a/spec/support/factories/locations.rb
+++ b/spec/support/factories/locations.rb
@@ -9,5 +9,13 @@ FactoryBot.define do
     zip             { Faker::Address.zip_code }
     lat             { "53.5#{rand(1000)}".to_f }
     long            { "9.9#{rand(1000)}".to_f }
+    virtual         { false }
+  end
+
+  factory :virtual_location, class: Location do
+    label           { 'hamburg' }
+    name            { Faker::Name.name }
+    url             { Faker::Internet.url }
+    virtual         { true }
   end
 end

--- a/spec/views/events/_info.html_spec.rb
+++ b/spec/views/events/_info.html_spec.rb
@@ -66,12 +66,24 @@ RSpec.describe 'events/show' do
     context 'when location is not present' do
       let(:location) { nil }
 
-      it 'should display the event location name' do
+      it 'should not display the event location name' do
         event = build(:event, location: location)
 
         render partial: 'info', locals: { event: event }
 
         expect(rendered).not_to match('example location')
+      end
+    end
+
+    context 'when location is virtual' do
+      let(:location) { build(:virtual_location, name: 'example virtual location') }
+
+      it 'should display the event location name' do
+        event = build(:event, location: location)
+
+        render partial: 'info', locals: { event: event }
+
+        expect(rendered).to match('example virtual location')
       end
     end
   end


### PR DESCRIPTION
- Added a 'virtual' flag for locations. If true, geographic attributes
  are not mandatory and geocoding is not performed upon object save.

- Added a 'remote_url' attribute to events. If present, only for users
  that have confirmed they will attend the event, a "Connect Remotely"
  button will appear in the event page.

With so many remote events, due to Covid-19, it's a good thing that we
don't have to add fake geo data to locations (streen, city,
lat/long...) Showing maps in the site for remote events is confusing.

In addition, each event can have a unique remote URL (like a Google
Meet or Zoom URL).

In this way, a virtual location can have a global URL (like the Twitch
page for the usergroup) and each event can have its own remote
URL (only useful during the event).

Hoping that you find these additions useful!!