### PR TITLE
Remove tmetzmac from Leipzg as organizer

### DIFF
--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -193,7 +193,6 @@
   organizers:
   - cpetschnig
   - knugie
-  - tmetzmac
   location:
     :zoom: 12
     :lat: 51.3417825


### PR DESCRIPTION
Hi, I'm not really involved anymore in the ruby user group in Leipzig. I want to remove myself from the list.

Thanks