### PR TITLE
Update colognerb slackin_url

### DIFF
--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -85,7 +85,7 @@
   domains:
   - colognerb.de
   google_group: colognerb
-  slackin_url: http://colognerb.herokuapp.com/slackin.js
+  slackin_url: https://colognerb.fly.dev/slackin.js
 - !ruby/object:Usergroup
   label_id: saar
   default_locale: de


### PR DESCRIPTION
Weil heruko sein free tier abgeschaltet hat dieses Jahr haben wir unseren slackin auf fly.io umgezogen und ich würde gerne einmal die URL hier updaten.